### PR TITLE
Ignore local agent/Claude Code config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,9 @@ npm-debug.log*
 # Lock files (using pnpm)
 package-lock.json
 yarn.lock
+
+# Agent / Claude Code config (local only)
+CLAUDE.md
+AGENTS.md
+CLAUDE.local.md
+.claude/


### PR DESCRIPTION
Adds a dedicated `.gitignore` section so agent/Claude Code config stays local-only and is never committed:

- `CLAUDE.md`
- `AGENTS.md`
- `CLAUDE.local.md` (moved out of the lock-files section)
- `.claude/`

No source or tooling changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project ignore rules to exclude local AI assistant configuration files and directories from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->