### PR TITLE
Add Biome for linting and formatting

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  },
+  "files": {
+    "includes": [
+      "**",
+      "!**/dist/**/*",
+      "!**/node_modules/**/*",
+      "!**/src/client/**/*"
+    ]
+  },
+  "css": {
+    "parser": {
+      "tailwindDirectives": true
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "suspicious": {
+        "noExplicitAny": "off",
+        "noArrayIndexKey": "off"
+      },
+      "style": {
+        "noNonNullAssertion": "off",
+        "noParameterAssign": "error",
+        "useSelfClosingElements": "error",
+        "noUselessElse": "error"
+      }
+    }
+  },
+  "formatter": {
+    "indentStyle": "space"
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "semicolons": "asNeeded"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -20,18 +20,21 @@
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",
-    "lint": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check . && tsc --noEmit",
+    "format": "biome check --write .",
     "clean": "rm -rf dist"
   },
   "dependencies": {
     "better-sqlite3": "^12.5.0",
+    "lib0": "^0.2.114",
     "sqlite-vec": "0.1.7-alpha.2",
-    "yjs": "^13.6.27",
     "y-indexeddb": "^9.0.12",
     "y-websocket": "^3.0.0",
-    "lib0": "^0.2.114"
+    "yjs": "^13.6.27"
   },
   "devDependencies": {
+    "@biomejs/biome": "2.5.3",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.0.0",
     "tsup": "^8.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
         specifier: ^13.6.27
         version: 13.6.27
     devDependencies:
+      '@biomejs/biome':
+        specifier: 2.5.3
+        version: 2.5.3
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13
@@ -44,6 +47,63 @@ importers:
         version: 2.1.9(@types/node@22.19.1)(terser@5.44.1)
 
 packages:
+
+  '@biomejs/biome@2.5.3':
+    resolution: {integrity: sha512-MrJswFdei9EfDwwUy2tQrPDpK0AO+RmMFvBoaaJ6ayBc3sUbHdCE+XG5N8vp+5So41ZupZJQm0roHFFhMGVD7A==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.5.3':
+    resolution: {integrity: sha512-QhYP9muVQ0nUO5zztFuPbEwi4+94sJWVjaZds9aMi1l/KNZBiUjdiSUrGHsTaMGDXrYl+r4AS2sUKfgH3w+V3g==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@2.5.3':
+    resolution: {integrity: sha512-NC1Ss13UaW7QZX+y8j44bF7AP0jSJdBl6iRhe0MAkvaSqZy+mWg3GaXsrb+eSoHoGDBtaXWEbMVV0iVN2cZ7cQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@2.5.3':
+    resolution: {integrity: sha512-fccix0w6xp6csCXgxeC0dU/3ecgRQal0y+cv2SP9ajNlhe7Yrk2Ug7UDe2j9AT9ZDYitkXpvUKgZjjuoYeP4Vg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-arm64@2.5.3':
+    resolution: {integrity: sha512-ksx1KWeyYW18ILL04msF/J4ZBtBDN33znYK8Z/aNv/vlBVxL9/g3mGP+omgHJKy4+KWbK87vcmmpmurfNjSgiA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-linux-x64-musl@2.5.3':
+    resolution: {integrity: sha512-O/yU9YKRUiHhmcjF2f38PSjseVk3G4VLWYc0G2HWpzdBVREV6G8IGWIVEFf7MFPfWIzNUIvPsEjeAZQIOgnLcQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-x64@2.5.3':
+    resolution: {integrity: sha512-yMkJtilsgvILDcVkh187aVLTb64xYsrxYajx5kym+r1ULkO5HUOfu9AYKLGQbOVLwJtT2utNw7hhFNg+17mUYA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-win32-arm64@2.5.3':
+    resolution: {integrity: sha512-cX5z+GYwRcqEok0AH3KSfQGgqYd0Nomfp6Fbe1uiTtELE38hdH2k842wQ9wLNaF/JJ7r4rjJQ4VR+ce+fRmQbw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.5.3':
+    resolution: {integrity: sha512-ExSaJWi4/u6+GXCszlSKpWSjKNbDseAYqqkCznsCsZ/4uidZ/BEqsCc5/3ctlq6dfIubdIIRSVLC/PG9xPl70Q==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -389,56 +449,67 @@ packages:
     resolution: {integrity: sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.53.3':
     resolution: {integrity: sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.53.3':
     resolution: {integrity: sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.53.3':
     resolution: {integrity: sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.53.3':
     resolution: {integrity: sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.53.3':
     resolution: {integrity: sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.53.3':
     resolution: {integrity: sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.53.3':
     resolution: {integrity: sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.53.3':
     resolution: {integrity: sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.53.3':
     resolution: {integrity: sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.53.3':
     resolution: {integrity: sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.53.3':
     resolution: {integrity: sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==}
@@ -1061,6 +1132,41 @@ packages:
     engines: {node: '>=16.0.0', npm: '>=8.0.0'}
 
 snapshots:
+
+  '@biomejs/biome@2.5.3':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.5.3
+      '@biomejs/cli-darwin-x64': 2.5.3
+      '@biomejs/cli-linux-arm64': 2.5.3
+      '@biomejs/cli-linux-arm64-musl': 2.5.3
+      '@biomejs/cli-linux-x64': 2.5.3
+      '@biomejs/cli-linux-x64-musl': 2.5.3
+      '@biomejs/cli-win32-arm64': 2.5.3
+      '@biomejs/cli-win32-x64': 2.5.3
+
+  '@biomejs/cli-darwin-arm64@2.5.3':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@2.5.3':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.5.3':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@2.5.3':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.5.3':
+    optional: true
+
+  '@biomejs/cli-linux-x64@2.5.3':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@2.5.3':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.5.3':
+    optional: true
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -4,47 +4,58 @@
  * Implements AES-256-GCM encryption with PBKDF2 key derivation.
  */
 
-import { randomBytes, createCipheriv, createDecipheriv, pbkdf2Sync } from "node:crypto";
+import {
+  createCipheriv,
+  createDecipheriv,
+  pbkdf2Sync,
+  randomBytes,
+} from "node:crypto"
 
-const ALGORITHM = "aes-256-gcm";
-const KEY_LENGTH = 32; // 256 bits
-const IV_LENGTH = 12; // 96 bits for GCM
-const AUTH_TAG_LENGTH = 16; // 128 bits
-const SALT_LENGTH = 32;
-const PBKDF2_ITERATIONS = 100000;
+const ALGORITHM = "aes-256-gcm"
+const KEY_LENGTH = 32 // 256 bits
+const IV_LENGTH = 12 // 96 bits for GCM
+const AUTH_TAG_LENGTH = 16 // 128 bits
+const SALT_LENGTH = 32
+const PBKDF2_ITERATIONS = 100000
 
 export interface EncryptedData {
   /** Base64-encoded ciphertext */
-  ciphertext: string;
+  ciphertext: string
   /** Base64-encoded initialization vector */
-  iv: string;
+  iv: string
   /** Base64-encoded authentication tag */
-  authTag: string;
+  authTag: string
   /** Base64-encoded salt (if key was derived from password) */
-  salt?: string;
+  salt?: string
 }
 
 export interface DerivedKey {
   /** The derived key bytes */
-  key: Buffer;
+  key: Buffer
   /** The salt used for derivation */
-  salt: Buffer;
+  salt: Buffer
 }
 
 /**
  * Derive an encryption key from a password using PBKDF2
  */
 export function deriveKey(password: string, salt?: Buffer): DerivedKey {
-  const actualSalt = salt ?? randomBytes(SALT_LENGTH);
-  const key = pbkdf2Sync(password, actualSalt, PBKDF2_ITERATIONS, KEY_LENGTH, "sha256");
-  return { key, salt: actualSalt };
+  const actualSalt = salt ?? randomBytes(SALT_LENGTH)
+  const key = pbkdf2Sync(
+    password,
+    actualSalt,
+    PBKDF2_ITERATIONS,
+    KEY_LENGTH,
+    "sha256",
+  )
+  return { key, salt: actualSalt }
 }
 
 /**
  * Generate a random encryption key
  */
 export function generateKey(): Buffer {
-  return randomBytes(KEY_LENGTH);
+  return randomBytes(KEY_LENGTH)
 }
 
 /**
@@ -54,23 +65,29 @@ export function generateKey(): Buffer {
  * @param key - 32-byte encryption key
  * @returns Encrypted data with IV and auth tag
  */
-export function encrypt(plaintext: string | Buffer, key: Buffer): EncryptedData {
+export function encrypt(
+  plaintext: string | Buffer,
+  key: Buffer,
+): EncryptedData {
   if (key.length !== KEY_LENGTH) {
-    throw new Error(`Key must be ${KEY_LENGTH} bytes (got ${key.length})`);
+    throw new Error(`Key must be ${KEY_LENGTH} bytes (got ${key.length})`)
   }
 
-  const iv = randomBytes(IV_LENGTH);
-  const cipher = createCipheriv(ALGORITHM, key, iv, { authTagLength: AUTH_TAG_LENGTH });
+  const iv = randomBytes(IV_LENGTH)
+  const cipher = createCipheriv(ALGORITHM, key, iv, {
+    authTagLength: AUTH_TAG_LENGTH,
+  })
 
-  const data = typeof plaintext === "string" ? Buffer.from(plaintext, "utf8") : plaintext;
-  const encrypted = Buffer.concat([cipher.update(data), cipher.final()]);
-  const authTag = cipher.getAuthTag();
+  const data =
+    typeof plaintext === "string" ? Buffer.from(plaintext, "utf8") : plaintext
+  const encrypted = Buffer.concat([cipher.update(data), cipher.final()])
+  const authTag = cipher.getAuthTag()
 
   return {
     ciphertext: encrypted.toString("base64"),
     iv: iv.toString("base64"),
     authTag: authTag.toString("base64"),
-  };
+  }
 }
 
 /**
@@ -83,49 +100,62 @@ export function encrypt(plaintext: string | Buffer, key: Buffer): EncryptedData 
  */
 export function decrypt(encrypted: EncryptedData, key: Buffer): string {
   if (key.length !== KEY_LENGTH) {
-    throw new Error(`Key must be ${KEY_LENGTH} bytes (got ${key.length})`);
+    throw new Error(`Key must be ${KEY_LENGTH} bytes (got ${key.length})`)
   }
 
-  const iv = Buffer.from(encrypted.iv, "base64");
-  const authTag = Buffer.from(encrypted.authTag, "base64");
-  const ciphertext = Buffer.from(encrypted.ciphertext, "base64");
+  const iv = Buffer.from(encrypted.iv, "base64")
+  const authTag = Buffer.from(encrypted.authTag, "base64")
+  const ciphertext = Buffer.from(encrypted.ciphertext, "base64")
 
-  const decipher = createDecipheriv(ALGORITHM, key, iv, { authTagLength: AUTH_TAG_LENGTH });
-  decipher.setAuthTag(authTag);
+  const decipher = createDecipheriv(ALGORITHM, key, iv, {
+    authTagLength: AUTH_TAG_LENGTH,
+  })
+  decipher.setAuthTag(authTag)
 
   try {
-    const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
-    return decrypted.toString("utf8");
-  } catch (error) {
-    throw new Error("Decryption failed: invalid key or tampered data");
+    const decrypted = Buffer.concat([
+      decipher.update(ciphertext),
+      decipher.final(),
+    ])
+    return decrypted.toString("utf8")
+  } catch {
+    throw new Error("Decryption failed: invalid key or tampered data")
   }
 }
 
 /**
  * Encrypt data with a password (derives key automatically)
  */
-export function encryptWithPassword(plaintext: string | Buffer, password: string): EncryptedData {
-  const { key, salt } = deriveKey(password);
-  const result = encrypt(plaintext, key);
-  result.salt = salt.toString("base64");
-  return result;
+export function encryptWithPassword(
+  plaintext: string | Buffer,
+  password: string,
+): EncryptedData {
+  const { key, salt } = deriveKey(password)
+  const result = encrypt(plaintext, key)
+  result.salt = salt.toString("base64")
+  return result
 }
 
 /**
  * Decrypt data with a password (derives key from stored salt)
  */
-export function decryptWithPassword(encrypted: EncryptedData, password: string): string {
+export function decryptWithPassword(
+  encrypted: EncryptedData,
+  password: string,
+): string {
   if (!encrypted.salt) {
-    throw new Error("No salt found in encrypted data - was this encrypted with a password?");
+    throw new Error(
+      "No salt found in encrypted data - was this encrypted with a password?",
+    )
   }
-  const salt = Buffer.from(encrypted.salt, "base64");
-  const { key } = deriveKey(password, salt);
-  return decrypt(encrypted, key);
+  const salt = Buffer.from(encrypted.salt, "base64")
+  const { key } = deriveKey(password, salt)
+  return decrypt(encrypted, key)
 }
 
 /**
  * Securely clear a buffer from memory
  */
 export function clearKey(key: Buffer): void {
-  key.fill(0);
+  key.fill(0)
 }

--- a/src/embeddings/index.ts
+++ b/src/embeddings/index.ts
@@ -1,1 +1,1 @@
-export { VectorStore } from "./vector-store.js";
+export { VectorStore } from "./vector-store.js"

--- a/src/embeddings/vector-store.ts
+++ b/src/embeddings/vector-store.ts
@@ -2,36 +2,40 @@
  * Vector Store - Semantic search over personal context
  */
 
-import type { EmbeddingConfig, SearchResult } from "../vault/types.js";
+import type { EmbeddingConfig, SearchResult } from "../vault/types.js"
 
 export interface VectorEntry {
-  id: string;
-  vector: Float32Array;
-  metadata?: Record<string, unknown>;
+  id: string
+  vector: Float32Array
+  metadata?: Record<string, unknown>
 }
 
 export class VectorStore {
-  private config: EmbeddingConfig;
-  private vectors: Map<string, VectorEntry> = new Map();
+  private config: EmbeddingConfig
+  private vectors: Map<string, VectorEntry> = new Map()
 
   constructor(config: EmbeddingConfig = {}) {
     this.config = {
       dimensions: 384, // Default for small embedding models
       ...config,
-    };
+    }
   }
 
   /**
    * Add a vector to the store
    */
-  async add(id: string, vector: Float32Array, metadata?: Record<string, unknown>): Promise<void> {
+  async add(
+    id: string,
+    vector: Float32Array,
+    metadata?: Record<string, unknown>,
+  ): Promise<void> {
     if (vector.length !== this.config.dimensions) {
       throw new Error(
-        `Vector dimension mismatch: expected ${this.config.dimensions}, got ${vector.length}`
-      );
+        `Vector dimension mismatch: expected ${this.config.dimensions}, got ${vector.length}`,
+      )
     }
 
-    this.vectors.set(id, { id, vector, metadata });
+    this.vectors.set(id, { id, vector, metadata })
   }
 
   /**
@@ -40,27 +44,31 @@ export class VectorStore {
   async embed(text: string): Promise<Float32Array> {
     // TODO: Integrate with actual embedding model
     // For now, return a placeholder vector
-    const vector = new Float32Array(this.config.dimensions!);
+    const vector = new Float32Array(this.config.dimensions!)
     // Simple hash-based placeholder (NOT a real embedding)
     for (let i = 0; i < text.length && i < vector.length; i++) {
-      vector[i] = text.charCodeAt(i) / 255;
+      vector[i] = text.charCodeAt(i) / 255
     }
-    return vector;
+    return vector
   }
 
   /**
    * Search for similar vectors
    */
   async search(query: Float32Array, topK = 10): Promise<SearchResult[]> {
-    const results: Array<{ id: string; score: number; metadata?: Record<string, unknown> }> = [];
+    const results: Array<{
+      id: string
+      score: number
+      metadata?: Record<string, unknown>
+    }> = []
 
     for (const entry of this.vectors.values()) {
-      const score = this.cosineSimilarity(query, entry.vector);
-      results.push({ id: entry.id, score, metadata: entry.metadata });
+      const score = this.cosineSimilarity(query, entry.vector)
+      results.push({ id: entry.id, score, metadata: entry.metadata })
     }
 
     // Sort by score descending
-    results.sort((a, b) => b.score - a.score);
+    results.sort((a, b) => b.score - a.score)
 
     return results.slice(0, topK).map((r) => ({
       data: {
@@ -71,45 +79,45 @@ export class VectorStore {
         version: 1,
       },
       score: r.score,
-    }));
+    }))
   }
 
   /**
    * Remove a vector from the store
    */
   async remove(id: string): Promise<boolean> {
-    return this.vectors.delete(id);
+    return this.vectors.delete(id)
   }
 
   /**
    * Get store size
    */
   size(): number {
-    return this.vectors.size;
+    return this.vectors.size
   }
 
   /**
    * Clear all vectors
    */
   clear(): void {
-    this.vectors.clear();
+    this.vectors.clear()
   }
 
   /**
    * Calculate cosine similarity between two vectors
    */
   private cosineSimilarity(a: Float32Array, b: Float32Array): number {
-    let dotProduct = 0;
-    let normA = 0;
-    let normB = 0;
+    let dotProduct = 0
+    let normA = 0
+    let normB = 0
 
     for (let i = 0; i < a.length; i++) {
-      dotProduct += a[i] * b[i];
-      normA += a[i] * a[i];
-      normB += b[i] * b[i];
+      dotProduct += a[i] * b[i]
+      normA += a[i] * a[i]
+      normB += b[i] * b[i]
     }
 
-    const magnitude = Math.sqrt(normA) * Math.sqrt(normB);
-    return magnitude === 0 ? 0 : dotProduct / magnitude;
+    const magnitude = Math.sqrt(normA) * Math.sqrt(normB)
+    return magnitude === 0 ? 0 : dotProduct / magnitude
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,39 +4,40 @@
  * Layer 1: Encrypted local-first data storage with CRDT sync
  */
 
-export { ContextStore } from "./vault/context-store.js";
-export { EncryptedVault } from "./vault/encrypted-vault.js";
-export { SyncedVault } from "./vault/synced-vault.js";
-export { CRDTSync } from "./sync/crdt-sync.js";
-export type { SyncedEntry, SyncedData, SyncEvent, SyncStatus } from "./sync/crdt-sync.js";
-export type { SyncedVaultConfig } from "./vault/synced-vault.js";
-export { VectorStore } from "./embeddings/vector-store.js";
-export { SQLiteVectorStore } from "./vectors/index.js";
-export type { VectorSearchResult, VectorStoreOptions } from "./vectors/index.js";
-
+export type { DerivedKey, EncryptedData } from "./crypto/index.js"
 // Crypto utilities
 export {
-  encrypt,
-  decrypt,
-  encryptWithPassword,
-  decryptWithPassword,
-  generateKey,
-  deriveKey,
   clearKey,
-} from "./crypto/index.js";
-
+  decrypt,
+  decryptWithPassword,
+  deriveKey,
+  encrypt,
+  encryptWithPassword,
+  generateKey,
+} from "./crypto/index.js"
+export { VectorStore } from "./embeddings/vector-store.js"
+export type { SQLiteStorageOptions, StoredEntry } from "./storage/sqlite.js"
 // Storage
-export { SQLiteStorage } from "./storage/sqlite.js";
-export type { StoredEntry, SQLiteStorageOptions } from "./storage/sqlite.js";
-
+export { SQLiteStorage } from "./storage/sqlite.js"
+export type {
+  SyncEvent,
+  SyncedData,
+  SyncedEntry,
+  SyncStatus,
+} from "./sync/crdt-sync.js"
+export { CRDTSync } from "./sync/crdt-sync.js"
+export { ContextStore } from "./vault/context-store.js"
+export { EncryptedVault } from "./vault/encrypted-vault.js"
+export type { SyncedVaultConfig } from "./vault/synced-vault.js"
+export { SyncedVault } from "./vault/synced-vault.js"
 // Types
 export type {
   ContextStoreConfig,
-  VaultConfig,
-  VaultData,
-  SyncConfig,
   EmbeddingConfig,
   StorageConfig,
-} from "./vault/types.js";
-
-export type { EncryptedData, DerivedKey } from "./crypto/index.js";
+  SyncConfig,
+  VaultConfig,
+  VaultData,
+} from "./vault/types.js"
+export type { VectorSearchResult, VectorStoreOptions } from "./vectors/index.js"
+export { SQLiteVectorStore } from "./vectors/index.js"

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,42 +11,46 @@
  * The SQLite database is stored locally.
  */
 
-import { createServer, IncomingMessage, ServerResponse } from "node:http";
-import Database from "better-sqlite3";
-import * as Y from "yjs";
-import * as fs from "node:fs";
-import * as path from "node:path";
+import * as fs from "node:fs"
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http"
+import * as path from "node:path"
+import Database from "better-sqlite3"
+import * as Y from "yjs"
 
-const PORT = parseInt(process.env.PORT || "8081", 10);
-const DATA_DIR = process.env.DATA_DIR || "./data";
+const PORT = parseInt(process.env.PORT || "8081", 10)
+const DATA_DIR = process.env.DATA_DIR || "./data"
 
 // Ensure data directory exists
 if (!fs.existsSync(DATA_DIR)) {
-  fs.mkdirSync(DATA_DIR, { recursive: true });
+  fs.mkdirSync(DATA_DIR, { recursive: true })
 }
 
 /**
  * Entry stored in the database (already encrypted by client)
  */
 interface StoredEntry {
-  key: string;
+  key: string
   /** The encrypted data blob (client encrypts before sending) */
-  encrypted_data: string;
-  created_at: string;
-  updated_at: string;
-  version: number;
+  encrypted_data: string
+  created_at: string
+  updated_at: string
+  version: number
 }
 
 /**
  * Per-user storage instance
  */
 class UserStorage {
-  private db: Database.Database;
-  private doc: Y.Doc;
+  private db: Database.Database
+  private doc: Y.Doc
 
   constructor(dbPath: string) {
-    this.db = new Database(dbPath);
-    this.db.pragma("journal_mode = WAL");
+    this.db = new Database(dbPath)
+    this.db.pragma("journal_mode = WAL")
 
     // Create tables
     this.db.exec(`
@@ -62,128 +66,158 @@ class UserStorage {
         id INTEGER PRIMARY KEY CHECK (id = 1),
         state BLOB NOT NULL
       );
-    `);
+    `)
 
     // Initialize Yjs doc for CRDT sync
-    this.doc = new Y.Doc();
-    this.loadCRDTState();
+    this.doc = new Y.Doc()
+    this.loadCRDTState()
   }
 
   private loadCRDTState(): void {
-    const row = this.db.prepare("SELECT state FROM crdt_state WHERE id = 1").get() as { state: Buffer } | undefined;
+    const row = this.db
+      .prepare("SELECT state FROM crdt_state WHERE id = 1")
+      .get() as { state: Buffer } | undefined
     if (row) {
-      Y.applyUpdate(this.doc, new Uint8Array(row.state));
+      Y.applyUpdate(this.doc, new Uint8Array(row.state))
     }
   }
 
   private saveCRDTState(): void {
-    const state = Y.encodeStateAsUpdate(this.doc);
-    this.db.prepare(
-      "INSERT OR REPLACE INTO crdt_state (id, state) VALUES (1, ?)"
-    ).run(Buffer.from(state));
+    const state = Y.encodeStateAsUpdate(this.doc)
+    this.db
+      .prepare("INSERT OR REPLACE INTO crdt_state (id, state) VALUES (1, ?)")
+      .run(Buffer.from(state))
   }
 
   keys(): string[] {
-    const rows = this.db.prepare("SELECT key FROM entries").all() as { key: string }[];
-    return rows.map((r) => r.key);
+    const rows = this.db.prepare("SELECT key FROM entries").all() as {
+      key: string
+    }[]
+    return rows.map((r) => r.key)
   }
 
   get(key: string): StoredEntry | null {
-    const row = this.db.prepare("SELECT * FROM entries WHERE key = ?").get(key) as StoredEntry | undefined;
-    return row || null;
+    const row = this.db
+      .prepare("SELECT * FROM entries WHERE key = ?")
+      .get(key) as StoredEntry | undefined
+    return row || null
   }
 
   put(key: string, encryptedData: string): StoredEntry {
-    const now = new Date().toISOString();
-    const existing = this.get(key);
-    const version = (existing?.version ?? 0) + 1;
+    const now = new Date().toISOString()
+    const existing = this.get(key)
+    const version = (existing?.version ?? 0) + 1
 
-    this.db.prepare(`
+    this.db
+      .prepare(`
       INSERT OR REPLACE INTO entries (key, encrypted_data, created_at, updated_at, version)
       VALUES (?, ?, ?, ?, ?)
-    `).run(key, encryptedData, existing?.created_at ?? now, now, version);
+    `)
+      .run(key, encryptedData, existing?.created_at ?? now, now, version)
 
     // Update CRDT
-    const entries = this.doc.getMap("entries");
+    const entries = this.doc.getMap("entries")
     this.doc.transact(() => {
-      entries.set(key, { encrypted_data: encryptedData, updated_at: now, version });
-    });
-    this.saveCRDTState();
+      entries.set(key, {
+        encrypted_data: encryptedData,
+        updated_at: now,
+        version,
+      })
+    })
+    this.saveCRDTState()
 
-    return { key, encrypted_data: encryptedData, created_at: existing?.created_at ?? now, updated_at: now, version };
+    return {
+      key,
+      encrypted_data: encryptedData,
+      created_at: existing?.created_at ?? now,
+      updated_at: now,
+      version,
+    }
   }
 
   delete(key: string): boolean {
-    const result = this.db.prepare("DELETE FROM entries WHERE key = ?").run(key);
+    const result = this.db.prepare("DELETE FROM entries WHERE key = ?").run(key)
     if (result.changes > 0) {
-      const entries = this.doc.getMap("entries");
+      const entries = this.doc.getMap("entries")
       this.doc.transact(() => {
-        entries.delete(key);
-      });
-      this.saveCRDTState();
-      return true;
+        entries.delete(key)
+      })
+      this.saveCRDTState()
+      return true
     }
-    return false;
+    return false
   }
 
   getStateVector(): Uint8Array {
-    return Y.encodeStateVector(this.doc);
+    return Y.encodeStateVector(this.doc)
   }
 
   getUpdatesSince(stateVector: Uint8Array): Uint8Array {
-    return Y.encodeStateAsUpdate(this.doc, stateVector);
+    return Y.encodeStateAsUpdate(this.doc, stateVector)
   }
 
   applyUpdate(update: Uint8Array): void {
-    Y.applyUpdate(this.doc, update);
-    this.saveCRDTState();
+    Y.applyUpdate(this.doc, update)
+    this.saveCRDTState()
 
     // Sync CRDT entries to SQLite
-    const entries = this.doc.getMap("entries");
+    const entries = this.doc.getMap("entries")
     entries.forEach((value, key) => {
-      const entry = value as { encrypted_data: string; updated_at: string; version: number };
-      const existing = this.get(key);
+      const entry = value as {
+        encrypted_data: string
+        updated_at: string
+        version: number
+      }
+      const existing = this.get(key)
       if (!existing || existing.version < entry.version) {
-        const now = new Date().toISOString();
-        this.db.prepare(`
+        const now = new Date().toISOString()
+        this.db
+          .prepare(`
           INSERT OR REPLACE INTO entries (key, encrypted_data, created_at, updated_at, version)
           VALUES (?, ?, ?, ?, ?)
-        `).run(key, entry.encrypted_data, existing?.created_at ?? now, entry.updated_at, entry.version);
+        `)
+          .run(
+            key,
+            entry.encrypted_data,
+            existing?.created_at ?? now,
+            entry.updated_at,
+            entry.version,
+          )
       }
-    });
+    })
   }
 
   close(): void {
-    this.doc.destroy();
-    this.db.close();
+    this.doc.destroy()
+    this.db.close()
   }
 }
 
 // Storage instances per user
-const storageInstances = new Map<string, UserStorage>();
+const storageInstances = new Map<string, UserStorage>()
 
 function getStorage(userId: string): UserStorage {
   if (!storageInstances.has(userId)) {
-    const dbPath = path.join(DATA_DIR, `${userId}.db`);
-    storageInstances.set(userId, new UserStorage(dbPath));
+    const dbPath = path.join(DATA_DIR, `${userId}.db`)
+    storageInstances.set(userId, new UserStorage(dbPath))
   }
-  return storageInstances.get(userId)!;
+  return storageInstances.get(userId)!
 }
 
 // Parse JSON body
 async function parseBody(req: IncomingMessage): Promise<unknown> {
   return new Promise((resolve, reject) => {
-    let body = "";
-    req.on("data", (chunk) => (body += chunk));
+    let body = ""
+    req.on("data", (chunk) => (body += chunk))
     req.on("end", () => {
       try {
-        resolve(body ? JSON.parse(body) : {});
+        resolve(body ? JSON.parse(body) : {})
       } catch (_e) {
-        reject(new Error("Invalid JSON"));
+        reject(new Error("Invalid JSON"))
       }
-    });
-    req.on("error", reject);
-  });
+    })
+    req.on("error", reject)
+  })
 }
 
 // CORS headers
@@ -191,157 +225,166 @@ const CORS_HEADERS = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
   "Access-Control-Allow-Headers": "Content-Type, X-User-ID",
-};
+}
 
 // Send JSON response
 function sendJson(res: ServerResponse, data: unknown, status = 200): void {
-  res.writeHead(status, { "Content-Type": "application/json", ...CORS_HEADERS });
-  res.end(JSON.stringify(data));
+  res.writeHead(status, { "Content-Type": "application/json", ...CORS_HEADERS })
+  res.end(JSON.stringify(data))
 }
 
 // Send error response
 function sendError(res: ServerResponse, message: string, status = 400): void {
-  sendJson(res, { error: message }, status);
+  sendJson(res, { error: message }, status)
 }
 
 // Route handlers
-async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
-  const url = new URL(req.url || "/", `http://localhost:${PORT}`);
-  const pathname = url.pathname;
-  const method = req.method || "GET";
+async function handleRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  const url = new URL(req.url || "/", `http://localhost:${PORT}`)
+  const pathname = url.pathname
+  const method = req.method || "GET"
 
   // CORS preflight
   if (method === "OPTIONS") {
-    res.writeHead(204, CORS_HEADERS);
-    res.end();
-    return;
+    res.writeHead(204, CORS_HEADERS)
+    res.end()
+    return
   }
 
   // Health check
   if (pathname === "/health") {
-    sendJson(res, { status: "healthy", users: storageInstances.size });
-    return;
+    sendJson(res, { status: "healthy", users: storageInstances.size })
+    return
   }
 
   // Get user ID from header (identifies the local user/device)
-  const userId = req.headers["x-user-id"] as string || "default";
-  const storage = getStorage(userId);
+  const userId = (req.headers["x-user-id"] as string) || "default"
+  const storage = getStorage(userId)
 
   try {
     // GET /entries - List all keys
     if (pathname === "/entries" && method === "GET") {
-      sendJson(res, { keys: storage.keys() });
-      return;
+      sendJson(res, { keys: storage.keys() })
+      return
     }
 
     // Match /entries/:key routes
-    const entryMatch = pathname.match(/^\/entries\/(.+)$/);
+    const entryMatch = pathname.match(/^\/entries\/(.+)$/)
 
     // GET /entries/:key - Get a specific entry
     if (entryMatch && method === "GET") {
-      const key = decodeURIComponent(entryMatch[1]);
-      const entry = storage.get(key);
+      const key = decodeURIComponent(entryMatch[1])
+      const entry = storage.get(key)
       if (entry) {
-        sendJson(res, entry);
+        sendJson(res, entry)
       } else {
-        sendError(res, "Not found", 404);
+        sendError(res, "Not found", 404)
       }
-      return;
+      return
     }
 
     // PUT /entries/:key - Store an entry (client sends pre-encrypted data)
     if (entryMatch && method === "PUT") {
-      const key = decodeURIComponent(entryMatch[1]);
-      const body = await parseBody(req) as { encrypted_data: string };
+      const key = decodeURIComponent(entryMatch[1])
+      const body = (await parseBody(req)) as { encrypted_data: string }
       if (!body.encrypted_data) {
-        sendError(res, "Missing 'encrypted_data' field");
-        return;
+        sendError(res, "Missing 'encrypted_data' field")
+        return
       }
-      const result = storage.put(key, body.encrypted_data);
-      sendJson(res, result, 201);
-      return;
+      const result = storage.put(key, body.encrypted_data)
+      sendJson(res, result, 201)
+      return
     }
 
     // DELETE /entries/:key - Delete an entry
     if (entryMatch && method === "DELETE") {
-      const key = decodeURIComponent(entryMatch[1]);
-      const deleted = storage.delete(key);
-      sendJson(res, { deleted });
-      return;
+      const key = decodeURIComponent(entryMatch[1])
+      const deleted = storage.delete(key)
+      sendJson(res, { deleted })
+      return
     }
 
     // POST /sync - Get CRDT update for sync
     if (pathname === "/sync" && method === "POST") {
-      const body = await parseBody(req) as { state_vector?: string };
-      let update: Uint8Array;
+      const body = (await parseBody(req)) as { state_vector?: string }
+      let update: Uint8Array
 
       if (body.state_vector) {
         // Get updates since the provided state vector
-        const stateVector = new Uint8Array(Buffer.from(body.state_vector, "base64"));
-        update = storage.getUpdatesSince(stateVector);
+        const stateVector = new Uint8Array(
+          Buffer.from(body.state_vector, "base64"),
+        )
+        update = storage.getUpdatesSince(stateVector)
       } else {
         // Get full state
-        update = storage.getUpdatesSince(new Uint8Array(0));
+        update = storage.getUpdatesSince(new Uint8Array(0))
       }
 
       sendJson(res, {
         update: Buffer.from(update).toString("base64"),
-      });
-      return;
+      })
+      return
     }
 
     // POST /sync/apply - Apply a sync update from another device
     if (pathname === "/sync/apply" && method === "POST") {
-      const body = await parseBody(req) as { update: string };
+      const body = (await parseBody(req)) as { update: string }
       if (!body.update) {
-        sendError(res, "Missing 'update' field");
-        return;
+        sendError(res, "Missing 'update' field")
+        return
       }
-      const updateBytes = new Uint8Array(Buffer.from(body.update, "base64"));
-      storage.applyUpdate(updateBytes);
-      sendJson(res, { applied: true });
-      return;
+      const updateBytes = new Uint8Array(Buffer.from(body.update, "base64"))
+      storage.applyUpdate(updateBytes)
+      sendJson(res, { applied: true })
+      return
     }
 
     // GET /sync/state - Get state vector for sync negotiation
     if (pathname === "/sync/state" && method === "GET") {
-      const stateVector = storage.getStateVector();
+      const stateVector = storage.getStateVector()
       sendJson(res, {
         state_vector: Buffer.from(stateVector).toString("base64"),
-      });
-      return;
+      })
+      return
     }
 
     // Not found
-    sendError(res, "Not found", 404);
+    sendError(res, "Not found", 404)
   } catch (error) {
-    console.error("Request error:", error);
-    sendError(res, error instanceof Error ? error.message : "Internal error", 500);
+    console.error("Request error:", error)
+    sendError(
+      res,
+      error instanceof Error ? error.message : "Internal error",
+      500,
+    )
   }
 }
 
 // Start server
 const server = createServer((req, res) => {
   handleRequest(req, res).catch((err) => {
-    console.error("Unhandled error:", err);
-    sendError(res, "Internal server error", 500);
-  });
-});
+    console.error("Unhandled error:", err)
+    sendError(res, "Internal server error", 500)
+  })
+})
 
 server.listen(PORT, () => {
-  console.log(`PCI Context Store server listening on port ${PORT}`);
-  console.log(`Data directory: ${DATA_DIR}`);
-});
+  console.log(`PCI Context Store server listening on port ${PORT}`)
+  console.log(`Data directory: ${DATA_DIR}`)
+})
 
 // Graceful shutdown
 process.on("SIGTERM", () => {
-  console.log("Shutting down...");
+  console.log("Shutting down...")
   for (const [userId, storage] of storageInstances) {
-    console.log(`Closing storage for user: ${userId}`);
-    storage.close();
+    console.log(`Closing storage for user: ${userId}`)
+    storage.close()
   }
   server.close(() => {
-    console.log("Server closed");
-    process.exit(0);
-  });
-});
+    console.log("Server closed")
+    process.exit(0)
+  })
+})

--- a/src/storage/sqlite.ts
+++ b/src/storage/sqlite.ts
@@ -5,45 +5,45 @@
  * encrypted - SQLite just provides the persistence layer.
  */
 
-import Database from "better-sqlite3";
-import type { EncryptedData } from "../crypto/index.js";
+import Database from "better-sqlite3"
+import type { EncryptedData } from "../crypto/index.js"
 
 export interface StoredEntry {
-  encrypted: EncryptedData;
-  createdAt: string;
-  updatedAt: string;
-  version: number;
+  encrypted: EncryptedData
+  createdAt: string
+  updatedAt: string
+  version: number
 }
 
 export interface SQLiteStorageOptions {
   /** Path to database file. Use ":memory:" for in-memory database */
-  path: string;
+  path: string
   /** Vault name/namespace for this storage instance */
-  vaultName: string;
+  vaultName: string
 }
 
 /**
  * SQLite-backed storage for encrypted vault entries
  */
 export class SQLiteStorage {
-  private db: Database.Database;
-  private vaultName: string;
+  private db: Database.Database
+  private vaultName: string
   private stmts: {
-    get: Database.Statement;
-    put: Database.Statement;
-    delete: Database.Statement;
-    keys: Database.Statement;
-    has: Database.Statement;
-    all: Database.Statement;
-    clear: Database.Statement;
-  };
+    get: Database.Statement
+    put: Database.Statement
+    delete: Database.Statement
+    keys: Database.Statement
+    has: Database.Statement
+    all: Database.Statement
+    clear: Database.Statement
+  }
 
   constructor(options: SQLiteStorageOptions) {
-    this.vaultName = options.vaultName;
-    this.db = new Database(options.path);
+    this.vaultName = options.vaultName
+    this.db = new Database(options.path)
 
     // Enable WAL mode for better concurrency
-    this.db.pragma("journal_mode = WAL");
+    this.db.pragma("journal_mode = WAL")
 
     // Create table if it doesn't exist
     this.db.exec(`
@@ -61,7 +61,7 @@ export class SQLiteStorage {
       );
 
       CREATE INDEX IF NOT EXISTS idx_vault_name ON vault_entries(vault_name);
-    `);
+    `)
 
     // Prepare statements for better performance
     this.stmts = {
@@ -93,7 +93,7 @@ export class SQLiteStorage {
       clear: this.db.prepare(`
         DELETE FROM vault_entries WHERE vault_name = ?
       `),
-    };
+    }
   }
 
   /**
@@ -102,18 +102,18 @@ export class SQLiteStorage {
   get(key: string): StoredEntry | undefined {
     const row = this.stmts.get.get(this.vaultName, key) as
       | {
-          ciphertext: string;
-          iv: string;
-          auth_tag: string;
-          salt: string | null;
-          created_at: string;
-          updated_at: string;
-          version: number;
+          ciphertext: string
+          iv: string
+          auth_tag: string
+          salt: string | null
+          created_at: string
+          updated_at: string
+          version: number
         }
-      | undefined;
+      | undefined
 
     if (!row) {
-      return undefined;
+      return undefined
     }
 
     return {
@@ -126,7 +126,7 @@ export class SQLiteStorage {
       createdAt: row.created_at,
       updatedAt: row.updated_at,
       version: row.version,
-    };
+    }
   }
 
   /**
@@ -142,31 +142,31 @@ export class SQLiteStorage {
       entry.encrypted.salt ?? null,
       entry.createdAt,
       entry.updatedAt,
-      entry.version
-    );
+      entry.version,
+    )
   }
 
   /**
    * Delete an entry
    */
   delete(key: string): boolean {
-    const result = this.stmts.delete.run(this.vaultName, key);
-    return result.changes > 0;
+    const result = this.stmts.delete.run(this.vaultName, key)
+    return result.changes > 0
   }
 
   /**
    * Get all keys in this vault
    */
   keys(): string[] {
-    const rows = this.stmts.keys.all(this.vaultName) as { entry_key: string }[];
-    return rows.map((row) => row.entry_key);
+    const rows = this.stmts.keys.all(this.vaultName) as { entry_key: string }[]
+    return rows.map((row) => row.entry_key)
   }
 
   /**
    * Check if a key exists
    */
   has(key: string): boolean {
-    return this.stmts.has.get(this.vaultName, key) !== undefined;
+    return this.stmts.has.get(this.vaultName, key) !== undefined
   }
 
   /**
@@ -174,17 +174,17 @@ export class SQLiteStorage {
    */
   getAll(): Record<string, StoredEntry> {
     const rows = this.stmts.all.all(this.vaultName) as {
-      entry_key: string;
-      ciphertext: string;
-      iv: string;
-      auth_tag: string;
-      salt: string | null;
-      created_at: string;
-      updated_at: string;
-      version: number;
-    }[];
+      entry_key: string
+      ciphertext: string
+      iv: string
+      auth_tag: string
+      salt: string | null
+      created_at: string
+      updated_at: string
+      version: number
+    }[]
 
-    const result: Record<string, StoredEntry> = {};
+    const result: Record<string, StoredEntry> = {}
     for (const row of rows) {
       result[row.entry_key] = {
         encrypted: {
@@ -196,9 +196,9 @@ export class SQLiteStorage {
         createdAt: row.created_at,
         updatedAt: row.updated_at,
         version: row.version,
-      };
+      }
     }
-    return result;
+    return result
   }
 
   /**
@@ -207,23 +207,23 @@ export class SQLiteStorage {
   importAll(entries: Record<string, StoredEntry>): void {
     const transaction = this.db.transaction(() => {
       for (const [key, entry] of Object.entries(entries)) {
-        this.put(key, entry);
+        this.put(key, entry)
       }
-    });
-    transaction();
+    })
+    transaction()
   }
 
   /**
    * Clear all entries in this vault
    */
   clear(): void {
-    this.stmts.clear.run(this.vaultName);
+    this.stmts.clear.run(this.vaultName)
   }
 
   /**
    * Close the database connection
    */
   close(): void {
-    this.db.close();
+    this.db.close()
   }
 }

--- a/src/sync/crdt-sync.ts
+++ b/src/sync/crdt-sync.ts
@@ -7,27 +7,38 @@
  * - Multiple provider support (WebSocket, WebRTC, etc.)
  */
 
-import * as Y from "yjs";
-import type { SyncConfig } from "../vault/types.js";
-import type { EncryptedData } from "../crypto/index.js";
+import * as Y from "yjs"
+import type { EncryptedData } from "../crypto/index.js"
+import type { SyncConfig } from "../vault/types.js"
 
-export type SyncStatus = "idle" | "connecting" | "syncing" | "connected" | "error";
+export type SyncStatus =
+  | "idle"
+  | "connecting"
+  | "syncing"
+  | "connected"
+  | "error"
 
 export interface SyncEvent {
-  type: "sync_start" | "sync_complete" | "sync_error" | "connected" | "disconnected" | "update";
-  timestamp: Date;
-  details?: unknown;
+  type:
+    | "sync_start"
+    | "sync_complete"
+    | "sync_error"
+    | "connected"
+    | "disconnected"
+    | "update"
+  timestamp: Date
+  details?: unknown
 }
 
 export interface SyncedEntry {
-  encrypted: EncryptedData;
-  createdAt: string;
-  updatedAt: string;
-  version: number;
+  encrypted: EncryptedData
+  createdAt: string
+  updatedAt: string
+  version: number
 }
 
 /** @deprecated Use SyncedEntry instead */
-export type SyncedData = SyncedEntry;
+export type SyncedData = SyncedEntry
 
 /**
  * Yjs-based CRDT Sync Engine
@@ -36,52 +47,52 @@ export type SyncedData = SyncedEntry;
  * across devices using y-websocket (self-hosted) or other providers.
  */
 export class CRDTSync {
-  private config: SyncConfig;
-  private status: SyncStatus = "idle";
-  private listeners: Set<(event: SyncEvent) => void> = new Set();
+  private config: SyncConfig
+  private status: SyncStatus = "idle"
+  private listeners: Set<(event: SyncEvent) => void> = new Set()
 
   /** The Yjs document - the core CRDT container */
-  private doc: Y.Doc;
+  private doc: Y.Doc
 
   /** Map of vault entries - synced across all peers */
-  private entries: Y.Map<SyncedEntry>;
+  private entries: Y.Map<SyncedEntry>
 
   /** WebSocket provider for network sync (lazy loaded) */
-  private wsProvider: unknown | null = null;
+  private wsProvider: unknown | null = null
 
   /** Periodic sync interval handle */
-  private syncInterval: ReturnType<typeof setInterval> | null = null;
+  private syncInterval: ReturnType<typeof setInterval> | null = null
 
   constructor(config: SyncConfig) {
-    this.config = config;
+    this.config = config
 
     // Initialize Yjs document
-    this.doc = new Y.Doc();
+    this.doc = new Y.Doc()
 
     // Create a shared map for vault entries
-    this.entries = this.doc.getMap<SyncedEntry>("entries");
+    this.entries = this.doc.getMap<SyncedEntry>("entries")
 
     // Listen for remote updates
     this.doc.on("update", (_update: Uint8Array, origin: unknown) => {
       // Only emit for remote updates (not our own changes)
       if (origin !== this) {
-        this.emit({ type: "update", timestamp: new Date() });
+        this.emit({ type: "update", timestamp: new Date() })
       }
-    });
+    })
   }
 
   /**
    * Get the underlying Y.Doc for direct access
    */
   getDoc(): Y.Doc {
-    return this.doc;
+    return this.doc
   }
 
   /**
    * Get the entries map for direct CRDT operations
    */
   getEntries(): Y.Map<SyncedEntry> {
-    return this.entries;
+    return this.entries
   }
 
   /**
@@ -89,49 +100,49 @@ export class CRDTSync {
    */
   set(key: string, data: SyncedEntry): void {
     this.doc.transact(() => {
-      this.entries.set(key, data);
-    }, this); // 'this' as origin to identify local changes
+      this.entries.set(key, data)
+    }, this) // 'this' as origin to identify local changes
   }
 
   /**
    * Get an entry
    */
   get(key: string): SyncedEntry | undefined {
-    return this.entries.get(key);
+    return this.entries.get(key)
   }
 
   /**
    * Delete an entry (CRDT operation - automatically synced)
    */
   remove(key: string): boolean {
-    const existed = this.entries.has(key);
+    const existed = this.entries.has(key)
     if (existed) {
       this.doc.transact(() => {
-        this.entries.delete(key);
-      }, this);
+        this.entries.delete(key)
+      }, this)
     }
-    return existed;
+    return existed
   }
 
   /**
    * Get all keys
    */
   keys(): string[] {
-    return Array.from(this.entries.keys());
+    return Array.from(this.entries.keys())
   }
 
   /**
    * Check if key exists
    */
   has(key: string): boolean {
-    return this.entries.has(key);
+    return this.entries.has(key)
   }
 
   /**
    * Get all entries as a plain object
    */
   toJSON(): Record<string, SyncedEntry> {
-    return this.entries.toJSON() as Record<string, SyncedEntry>;
+    return this.entries.toJSON() as Record<string, SyncedEntry>
   }
 
   /**
@@ -140,9 +151,9 @@ export class CRDTSync {
   importEntries(data: Record<string, SyncedEntry>): void {
     this.doc.transact(() => {
       for (const [key, value] of Object.entries(data)) {
-        this.entries.set(key, value);
+        this.entries.set(key, value)
       }
-    }, this);
+    }, this)
   }
 
   /**
@@ -150,63 +161,67 @@ export class CRDTSync {
    */
   async start(): Promise<void> {
     if (this.config.mode === "realtime" && this.config.peers?.length) {
-      await this.connectToPeers();
+      await this.connectToPeers()
     }
 
     if (this.config.mode === "periodic" && this.config.intervalMs) {
       this.syncInterval = setInterval(() => {
         this.syncNow().catch((err) => {
-          this.emit({ type: "sync_error", timestamp: new Date(), details: err });
-        });
-      }, this.config.intervalMs);
+          this.emit({ type: "sync_error", timestamp: new Date(), details: err })
+        })
+      }, this.config.intervalMs)
     }
 
-    this.emit({ type: "sync_start", timestamp: new Date() });
+    this.emit({ type: "sync_start", timestamp: new Date() })
   }
 
   /**
    * Connect to WebSocket peers for realtime sync
    */
   private async connectToPeers(): Promise<void> {
-    if (!this.config.peers?.length) return;
+    if (!this.config.peers?.length) return
 
-    this.status = "connecting";
+    this.status = "connecting"
 
     // Dynamic import to avoid issues in non-browser environments
     try {
-      const { WebsocketProvider } = await import("y-websocket");
+      const { WebsocketProvider } = await import("y-websocket")
 
       // Connect to first peer (could extend to multiple)
-      const serverUrl = this.config.peers[0];
-      const roomName = "pci-vault"; // Could be configurable per vault
+      const serverUrl = this.config.peers[0]
+      const roomName = "pci-vault" // Could be configurable per vault
 
-      this.wsProvider = new WebsocketProvider(serverUrl, roomName, this.doc);
+      this.wsProvider = new WebsocketProvider(serverUrl, roomName, this.doc)
 
       // Type assertion for event handling
       const provider = this.wsProvider as {
-        on: (event: string, callback: () => void) => void;
-        destroy: () => void;
-        wsconnected: boolean;
-      };
+        on: (event: string, callback: () => void) => void
+        destroy: () => void
+        wsconnected: boolean
+      }
 
       provider.on("sync", () => {
-        this.status = "connected";
-        this.emit({ type: "connected", timestamp: new Date() });
-      });
+        this.status = "connected"
+        this.emit({ type: "connected", timestamp: new Date() })
+      })
 
       provider.on("connection-close", () => {
-        this.status = "idle";
-        this.emit({ type: "disconnected", timestamp: new Date() });
-      });
+        this.status = "idle"
+        this.emit({ type: "disconnected", timestamp: new Date() })
+      })
 
       provider.on("connection-error", () => {
-        this.status = "error";
-        this.emit({ type: "sync_error", timestamp: new Date(), details: "Connection error" });
-      });
+        this.status = "error"
+        this.emit({
+          type: "sync_error",
+          timestamp: new Date(),
+          details: "Connection error",
+        })
+      })
     } catch (err) {
-      this.status = "error";
-      this.emit({ type: "sync_error", timestamp: new Date(), details: err });
-      throw err;
+      this.status = "error"
+      this.emit({ type: "sync_error", timestamp: new Date(), details: err })
+      throw err
     }
   }
 
@@ -216,19 +231,19 @@ export class CRDTSync {
   async stop(): Promise<void> {
     // Stop periodic sync
     if (this.syncInterval) {
-      clearInterval(this.syncInterval);
-      this.syncInterval = null;
+      clearInterval(this.syncInterval)
+      this.syncInterval = null
     }
 
     // Disconnect WebSocket provider
     if (this.wsProvider) {
-      const provider = this.wsProvider as { destroy: () => void };
-      provider.destroy();
-      this.wsProvider = null;
+      const provider = this.wsProvider as { destroy: () => void }
+      provider.destroy()
+      this.wsProvider = null
     }
 
-    this.status = "idle";
-    this.emit({ type: "disconnected", timestamp: new Date() });
+    this.status = "idle"
+    this.emit({ type: "disconnected", timestamp: new Date() })
   }
 
   /**
@@ -236,22 +251,22 @@ export class CRDTSync {
    */
   async syncNow(): Promise<Uint8Array> {
     if (this.status === "syncing") {
-      return Y.encodeStateAsUpdate(this.doc);
+      return Y.encodeStateAsUpdate(this.doc)
     }
 
-    this.status = "syncing";
-    this.emit({ type: "sync_start", timestamp: new Date() });
+    this.status = "syncing"
+    this.emit({ type: "sync_start", timestamp: new Date() })
 
     try {
       // Get the current state as an update
-      const update = Y.encodeStateAsUpdate(this.doc);
-      this.emit({ type: "sync_complete", timestamp: new Date() });
-      return update;
+      const update = Y.encodeStateAsUpdate(this.doc)
+      this.emit({ type: "sync_complete", timestamp: new Date() })
+      return update
     } catch (error) {
-      this.emit({ type: "sync_error", timestamp: new Date(), details: error });
-      throw error;
+      this.emit({ type: "sync_error", timestamp: new Date(), details: error })
+      throw error
     } finally {
-      this.status = this.wsProvider ? "connected" : "idle";
+      this.status = this.wsProvider ? "connected" : "idle"
     }
   }
 
@@ -259,39 +274,39 @@ export class CRDTSync {
    * Apply an update from another peer
    */
   applyUpdate(update: Uint8Array, origin?: unknown): void {
-    Y.applyUpdate(this.doc, update, origin);
+    Y.applyUpdate(this.doc, update, origin)
   }
 
   /**
    * Get the full state vector for sync negotiation
    */
   getStateVector(): Uint8Array {
-    return Y.encodeStateVector(this.doc);
+    return Y.encodeStateVector(this.doc)
   }
 
   /**
    * Get updates since a given state vector
    */
   getUpdatesSince(stateVector: Uint8Array): Uint8Array {
-    return Y.encodeStateAsUpdate(this.doc, stateVector);
+    return Y.encodeStateAsUpdate(this.doc, stateVector)
   }
 
   /**
    * Get current sync status
    */
   getStatus(): SyncStatus {
-    return this.status;
+    return this.status
   }
 
   /**
    * Add a peer for syncing
    */
   async addPeer(endpoint: string): Promise<void> {
-    this.config.peers = [...(this.config.peers ?? []), endpoint];
+    this.config.peers = [...(this.config.peers ?? []), endpoint]
 
     // If in realtime mode and running, connect to new peer
     if (this.config.mode === "realtime" && !this.wsProvider) {
-      await this.connectToPeers();
+      await this.connectToPeers()
     }
   }
 
@@ -299,14 +314,14 @@ export class CRDTSync {
    * Remove a peer
    */
   async removePeer(endpoint: string): Promise<void> {
-    this.config.peers = this.config.peers?.filter((p) => p !== endpoint);
+    this.config.peers = this.config.peers?.filter((p) => p !== endpoint)
 
     // If no peers left, disconnect
     if (!this.config.peers?.length && this.wsProvider) {
-      const provider = this.wsProvider as { destroy: () => void };
-      provider.destroy();
-      this.wsProvider = null;
-      this.status = "idle";
+      const provider = this.wsProvider as { destroy: () => void }
+      provider.destroy()
+      this.wsProvider = null
+      this.status = "idle"
     }
   }
 
@@ -314,30 +329,32 @@ export class CRDTSync {
    * Subscribe to sync events
    */
   onEvent(listener: (event: SyncEvent) => void): () => void {
-    this.listeners.add(listener);
-    return () => this.listeners.delete(listener);
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
   }
 
   /**
    * Subscribe to entry changes
    */
-  onEntriesChange(callback: (event: Y.YMapEvent<SyncedEntry>) => void): () => void {
-    this.entries.observe(callback);
-    return () => this.entries.unobserve(callback);
+  onEntriesChange(
+    callback: (event: Y.YMapEvent<SyncedEntry>) => void,
+  ): () => void {
+    this.entries.observe(callback)
+    return () => this.entries.unobserve(callback)
   }
 
   /**
    * Destroy the sync engine and cleanup
    */
   destroy(): void {
-    this.stop();
-    this.doc.destroy();
-    this.listeners.clear();
+    this.stop()
+    this.doc.destroy()
+    this.listeners.clear()
   }
 
   private emit(event: SyncEvent): void {
     for (const listener of this.listeners) {
-      listener(event);
+      listener(event)
     }
   }
 }

--- a/src/sync/index.ts
+++ b/src/sync/index.ts
@@ -1,1 +1,1 @@
-export { CRDTSync } from "./crdt-sync.js";
+export { CRDTSync } from "./crdt-sync.js"

--- a/src/vault/context-store.ts
+++ b/src/vault/context-store.ts
@@ -2,12 +2,12 @@
  * Context Store - Main entry point for PCI data storage
  */
 
-import type { ContextStoreConfig, VaultConfig } from "./types.js";
-import { EncryptedVault } from "./encrypted-vault.js";
+import { EncryptedVault } from "./encrypted-vault.js"
+import type { ContextStoreConfig, VaultConfig } from "./types.js"
 
 export class ContextStore {
-  private config: ContextStoreConfig;
-  private vaults: Map<string, EncryptedVault> = new Map();
+  private config: ContextStoreConfig
+  private vaults: Map<string, EncryptedVault> = new Map()
 
   constructor(config: ContextStoreConfig = {}) {
     this.config = {
@@ -17,55 +17,58 @@ export class ContextStore {
         ...config.encryption,
       },
       ...config,
-    };
+    }
   }
 
   /**
    * Create a new encrypted vault
    */
-  async createVault(name: string, options?: Partial<VaultConfig>): Promise<EncryptedVault> {
+  async createVault(
+    name: string,
+    options?: Partial<VaultConfig>,
+  ): Promise<EncryptedVault> {
     if (this.vaults.has(name)) {
-      throw new Error(`Vault "${name}" already exists`);
+      throw new Error(`Vault "${name}" already exists`)
     }
 
     const vault = new EncryptedVault({
       name,
       encryption: this.config.encryption,
       ...options,
-    });
+    })
 
-    await vault.initialize();
-    this.vaults.set(name, vault);
+    await vault.initialize()
+    this.vaults.set(name, vault)
 
-    return vault;
+    return vault
   }
 
   /**
    * Get an existing vault by name
    */
   getVault(name: string): EncryptedVault | undefined {
-    return this.vaults.get(name);
+    return this.vaults.get(name)
   }
 
   /**
    * List all vault names
    */
   listVaults(): string[] {
-    return Array.from(this.vaults.keys());
+    return Array.from(this.vaults.keys())
   }
 
   /**
    * Delete a vault and all its data
    */
   async deleteVault(name: string): Promise<boolean> {
-    const vault = this.vaults.get(name);
+    const vault = this.vaults.get(name)
     if (!vault) {
-      return false;
+      return false
     }
 
-    await vault.destroy();
-    this.vaults.delete(name);
-    return true;
+    await vault.destroy()
+    this.vaults.delete(name)
+    return true
   }
 
   /**
@@ -73,8 +76,8 @@ export class ContextStore {
    */
   async close(): Promise<void> {
     for (const vault of this.vaults.values()) {
-      await vault.destroy();
+      await vault.destroy()
     }
-    this.vaults.clear();
+    this.vaults.clear()
   }
 }

--- a/src/vault/encrypted-vault.ts
+++ b/src/vault/encrypted-vault.ts
@@ -5,123 +5,123 @@
  * Supports both in-memory (for testing) and SQLite (for persistence) backends.
  */
 
-import type { VaultConfig, VaultData, StorageConfig } from "./types.js";
 import {
-  encrypt,
-  decrypt,
-  generateKey,
-  deriveKey,
   clearKey,
-} from "../crypto/index.js";
-import { SQLiteStorage, type StoredEntry } from "../storage/sqlite.js";
+  decrypt,
+  deriveKey,
+  encrypt,
+  generateKey,
+} from "../crypto/index.js"
+import { SQLiteStorage, type StoredEntry } from "../storage/sqlite.js"
+import type { StorageConfig, VaultConfig, VaultData } from "./types.js"
 
 /**
  * Storage backend interface
  */
 interface StorageBackend {
-  get(key: string): StoredEntry | undefined;
-  put(key: string, entry: StoredEntry): void;
-  delete(key: string): boolean;
-  keys(): string[];
-  has(key: string): boolean;
-  getAll(): Record<string, StoredEntry>;
-  importAll(entries: Record<string, StoredEntry>): void;
-  clear(): void;
-  close(): void;
+  get(key: string): StoredEntry | undefined
+  put(key: string, entry: StoredEntry): void
+  delete(key: string): boolean
+  keys(): string[]
+  has(key: string): boolean
+  getAll(): Record<string, StoredEntry>
+  importAll(entries: Record<string, StoredEntry>): void
+  clear(): void
+  close(): void
 }
 
 /**
  * In-memory storage backend
  */
 class MemoryStorage implements StorageBackend {
-  private data: Map<string, StoredEntry> = new Map();
+  private data: Map<string, StoredEntry> = new Map()
 
   get(key: string): StoredEntry | undefined {
-    return this.data.get(key);
+    return this.data.get(key)
   }
 
   put(key: string, entry: StoredEntry): void {
-    this.data.set(key, entry);
+    this.data.set(key, entry)
   }
 
   delete(key: string): boolean {
-    return this.data.delete(key);
+    return this.data.delete(key)
   }
 
   keys(): string[] {
-    return Array.from(this.data.keys());
+    return Array.from(this.data.keys())
   }
 
   has(key: string): boolean {
-    return this.data.has(key);
+    return this.data.has(key)
   }
 
   getAll(): Record<string, StoredEntry> {
-    const result: Record<string, StoredEntry> = {};
+    const result: Record<string, StoredEntry> = {}
     for (const [key, entry] of this.data.entries()) {
-      result[key] = { ...entry };
+      result[key] = { ...entry }
     }
-    return result;
+    return result
   }
 
   importAll(entries: Record<string, StoredEntry>): void {
     for (const [key, entry] of Object.entries(entries)) {
-      this.data.set(key, entry);
+      this.data.set(key, entry)
     }
   }
 
   clear(): void {
-    this.data.clear();
+    this.data.clear()
   }
 
   close(): void {
-    this.clear();
+    this.clear()
   }
 }
 
 export class EncryptedVault {
-  private config: VaultConfig;
-  private storage: StorageBackend;
-  private encryptionKey: Buffer | null = null;
-  private initialized = false;
+  private config: VaultConfig
+  private storage: StorageBackend
+  private encryptionKey: Buffer | null = null
+  private initialized = false
 
   constructor(config: VaultConfig) {
     this.config = {
       schemaVersion: "1.0",
       storage: { type: "memory" },
       ...config,
-    };
+    }
 
     // Create storage backend
-    this.storage = this.createStorage(this.config.storage!);
+    this.storage = this.createStorage(this.config.storage!)
   }
 
   private createStorage(storageConfig: StorageConfig): StorageBackend {
     if (storageConfig.type === "sqlite") {
-      const path = storageConfig.path ?? `${this.config.name}.db`;
+      const path = storageConfig.path ?? `${this.config.name}.db`
       return new SQLiteStorage({
         path,
         vaultName: this.config.name,
-      });
+      })
     }
-    return new MemoryStorage();
+    return new MemoryStorage()
   }
 
   /**
    * Initialize the vault with a random key
    */
   async initialize(): Promise<void> {
-    this.encryptionKey = generateKey();
-    this.initialized = true;
+    this.encryptionKey = generateKey()
+    this.initialized = true
   }
 
   /**
    * Initialize the vault with a password-derived key
    */
   async initializeWithPassword(password: string): Promise<void> {
-    const { key } = deriveKey(password);
-    this.encryptionKey = key;
-    this.initialized = true;
+    const { key } = deriveKey(password)
+    this.encryptionKey = key
+    this.initialized = true
   }
 
   /**
@@ -129,33 +129,33 @@ export class EncryptedVault {
    */
   async initializeWithKey(key: Buffer): Promise<void> {
     if (key.length !== 32) {
-      throw new Error("Key must be 32 bytes (256 bits)");
+      throw new Error("Key must be 32 bytes (256 bits)")
     }
-    this.encryptionKey = Buffer.from(key); // Copy to avoid external mutation
-    this.initialized = true;
+    this.encryptionKey = Buffer.from(key) // Copy to avoid external mutation
+    this.initialized = true
   }
 
   /**
    * Store data in the vault (encrypted)
    */
   async put<T>(key: string, value: T): Promise<VaultData<T>> {
-    this.ensureInitialized();
+    this.ensureInitialized()
 
-    const now = new Date();
-    const existing = this.storage.get(key);
+    const now = new Date()
+    const existing = this.storage.get(key)
 
     // Serialize and encrypt the data
-    const plaintext = JSON.stringify(value);
-    const encrypted = encrypt(plaintext, this.encryptionKey!);
+    const plaintext = JSON.stringify(value)
+    const encrypted = encrypt(plaintext, this.encryptionKey!)
 
     const entry: StoredEntry = {
       encrypted,
       createdAt: existing?.createdAt ?? now.toISOString(),
       updatedAt: now.toISOString(),
       version: (existing?.version ?? 0) + 1,
-    };
+    }
 
-    this.storage.put(key, entry);
+    this.storage.put(key, entry)
 
     return {
       id: key,
@@ -163,23 +163,23 @@ export class EncryptedVault {
       createdAt: existing?.createdAt ? new Date(existing.createdAt) : now,
       updatedAt: now,
       version: entry.version,
-    };
+    }
   }
 
   /**
    * Retrieve and decrypt data from the vault
    */
   async get<T>(key: string): Promise<VaultData<T> | undefined> {
-    this.ensureInitialized();
+    this.ensureInitialized()
 
-    const entry = this.storage.get(key);
+    const entry = this.storage.get(key)
     if (!entry) {
-      return undefined;
+      return undefined
     }
 
     // Decrypt and deserialize
-    const plaintext = decrypt(entry.encrypted, this.encryptionKey!);
-    const data = JSON.parse(plaintext) as T;
+    const plaintext = decrypt(entry.encrypted, this.encryptionKey!)
+    const data = JSON.parse(plaintext) as T
 
     return {
       id: key,
@@ -187,54 +187,54 @@ export class EncryptedVault {
       createdAt: new Date(entry.createdAt),
       updatedAt: new Date(entry.updatedAt),
       version: entry.version,
-    };
+    }
   }
 
   /**
    * Delete data from the vault
    */
   async delete(key: string): Promise<boolean> {
-    this.ensureInitialized();
-    return this.storage.delete(key);
+    this.ensureInitialized()
+    return this.storage.delete(key)
   }
 
   /**
    * List all keys in the vault
    */
   async keys(): Promise<string[]> {
-    this.ensureInitialized();
-    return this.storage.keys();
+    this.ensureInitialized()
+    return this.storage.keys()
   }
 
   /**
    * Check if a key exists
    */
   async has(key: string): Promise<boolean> {
-    this.ensureInitialized();
-    return this.storage.has(key);
+    this.ensureInitialized()
+    return this.storage.has(key)
   }
 
   /**
    * Get vault metadata
    */
   getConfig(): VaultConfig {
-    return { ...this.config };
+    return { ...this.config }
   }
 
   /**
    * Export encrypted data for persistence/sync
    */
   async export(): Promise<Record<string, StoredEntry>> {
-    this.ensureInitialized();
-    return this.storage.getAll();
+    this.ensureInitialized()
+    return this.storage.getAll()
   }
 
   /**
    * Import encrypted data from persistence/sync
    */
   async import(data: Record<string, StoredEntry>): Promise<void> {
-    this.ensureInitialized();
-    this.storage.importAll(data);
+    this.ensureInitialized()
+    this.storage.importAll(data)
   }
 
   /**
@@ -243,16 +243,16 @@ export class EncryptedVault {
   async destroy(): Promise<void> {
     // Securely clear the encryption key from memory
     if (this.encryptionKey) {
-      clearKey(this.encryptionKey);
-      this.encryptionKey = null;
+      clearKey(this.encryptionKey)
+      this.encryptionKey = null
     }
-    this.storage.close();
-    this.initialized = false;
+    this.storage.close()
+    this.initialized = false
   }
 
   private ensureInitialized(): void {
     if (!this.initialized || !this.encryptionKey) {
-      throw new Error("Vault not initialized. Call initialize() first.");
+      throw new Error("Vault not initialized. Call initialize() first.")
     }
   }
 }

--- a/src/vault/index.ts
+++ b/src/vault/index.ts
@@ -1,3 +1,3 @@
-export { ContextStore } from "./context-store.js";
-export { EncryptedVault } from "./encrypted-vault.js";
-export type * from "./types.js";
+export { ContextStore } from "./context-store.js"
+export { EncryptedVault } from "./encrypted-vault.js"
+export type * from "./types.js"

--- a/src/vault/synced-vault.ts
+++ b/src/vault/synced-vault.ts
@@ -5,13 +5,18 @@
  * multi-device replication without conflicts.
  */
 
-import type { VaultConfig, VaultData, SyncConfig } from "./types.js";
-import { EncryptedVault } from "./encrypted-vault.js";
-import { CRDTSync, type SyncedEntry, type SyncEvent, type SyncStatus } from "../sync/crdt-sync.js";
-import type { StoredEntry } from "../storage/sqlite.js";
+import type { StoredEntry } from "../storage/sqlite.js"
+import {
+  CRDTSync,
+  type SyncEvent,
+  type SyncedEntry,
+  type SyncStatus,
+} from "../sync/crdt-sync.js"
+import { EncryptedVault } from "./encrypted-vault.js"
+import type { SyncConfig, VaultConfig, VaultData } from "./types.js"
 
 export interface SyncedVaultConfig extends VaultConfig {
-  sync?: SyncConfig;
+  sync?: SyncConfig
 }
 
 /**
@@ -21,39 +26,39 @@ export interface SyncedVaultConfig extends VaultConfig {
  * Remote changes are automatically applied to local storage.
  */
 export class SyncedVault {
-  private vault: EncryptedVault;
-  private sync: CRDTSync;
-  private config: SyncedVaultConfig;
-  private syncUnsubscribe: (() => void) | null = null;
+  private vault: EncryptedVault
+  private sync: CRDTSync
+  private config: SyncedVaultConfig
+  private syncUnsubscribe: (() => void) | null = null
 
   constructor(config: SyncedVaultConfig) {
-    this.config = config;
-    this.vault = new EncryptedVault(config);
-    this.sync = new CRDTSync(config.sync ?? { mode: "manual" });
+    this.config = config
+    this.vault = new EncryptedVault(config)
+    this.sync = new CRDTSync(config.sync ?? { mode: "manual" })
   }
 
   /**
    * Initialize the vault with a random key
    */
   async initialize(): Promise<void> {
-    await this.vault.initialize();
-    await this.setupSync();
+    await this.vault.initialize()
+    await this.setupSync()
   }
 
   /**
    * Initialize the vault with a password-derived key
    */
   async initializeWithPassword(password: string): Promise<void> {
-    await this.vault.initializeWithPassword(password);
-    await this.setupSync();
+    await this.vault.initializeWithPassword(password)
+    await this.setupSync()
   }
 
   /**
    * Initialize the vault with an existing key
    */
   async initializeWithKey(key: Buffer): Promise<void> {
-    await this.vault.initializeWithKey(key);
-    await this.setupSync();
+    await this.vault.initializeWithKey(key)
+    await this.setupSync()
   }
 
   /**
@@ -61,42 +66,45 @@ export class SyncedVault {
    */
   private async setupSync(): Promise<void> {
     // Load existing vault data into CRDT
-    const entries = await this.vault.export();
-    const syncEntries: Record<string, SyncedEntry> = {};
+    const entries = await this.vault.export()
+    const syncEntries: Record<string, SyncedEntry> = {}
     for (const [key, entry] of Object.entries(entries)) {
-      syncEntries[key] = this.storedToSynced(entry);
+      syncEntries[key] = this.storedToSynced(entry)
     }
-    this.sync.importEntries(syncEntries);
+    this.sync.importEntries(syncEntries)
 
     // Listen for remote changes
     this.syncUnsubscribe = this.sync.onEntriesChange((event) => {
       // Apply remote changes to local storage
       event.changes.keys.forEach((change, key) => {
         if (change.action === "add" || change.action === "update") {
-          const entry = this.sync.get(key);
+          const entry = this.sync.get(key)
           if (entry) {
             // Update local storage (bypassing vault to avoid re-encryption)
-            this.applyRemoteEntry(key, entry);
+            this.applyRemoteEntry(key, entry)
           }
         } else if (change.action === "delete") {
-          this.vault.delete(key);
+          this.vault.delete(key)
         }
-      });
-    });
+      })
+    })
 
     // Start sync if configured
     if (this.config.sync?.mode !== "manual") {
-      await this.sync.start();
+      await this.sync.start()
     }
   }
 
   /**
    * Apply a remote entry to local storage
    */
-  private async applyRemoteEntry(key: string, entry: SyncedEntry): Promise<void> {
+  private async applyRemoteEntry(
+    key: string,
+    entry: SyncedEntry,
+  ): Promise<void> {
     // Import directly to storage (already encrypted)
-    const stored = this.syncedToStored(entry);
-    await this.vault.import({ [key]: stored });
+    const stored = this.syncedToStored(entry)
+    await this.vault.import({ [key]: stored })
   }
 
   /**
@@ -108,7 +116,7 @@ export class SyncedVault {
       createdAt: entry.createdAt,
       updatedAt: entry.updatedAt,
       version: entry.version,
-    };
+    }
   }
 
   /**
@@ -120,139 +128,139 @@ export class SyncedVault {
       createdAt: entry.createdAt,
       updatedAt: entry.updatedAt,
       version: entry.version,
-    };
+    }
   }
 
   /**
    * Store data in the vault (encrypted + synced)
    */
   async put<T>(key: string, value: T): Promise<VaultData<T>> {
-    const result = await this.vault.put(key, value);
+    const result = await this.vault.put(key, value)
 
     // Update CRDT with the encrypted entry
-    const entries = await this.vault.export();
-    const stored = entries[key];
+    const entries = await this.vault.export()
+    const stored = entries[key]
     if (stored) {
-      this.sync.set(key, this.storedToSynced(stored));
+      this.sync.set(key, this.storedToSynced(stored))
     }
 
-    return result;
+    return result
   }
 
   /**
    * Retrieve and decrypt data from the vault
    */
   async get<T>(key: string): Promise<VaultData<T> | undefined> {
-    return this.vault.get<T>(key);
+    return this.vault.get<T>(key)
   }
 
   /**
    * Delete data from the vault (synced)
    */
   async delete(key: string): Promise<boolean> {
-    const result = await this.vault.delete(key);
+    const result = await this.vault.delete(key)
     if (result) {
-      this.sync.remove(key);
+      this.sync.remove(key)
     }
-    return result;
+    return result
   }
 
   /**
    * List all keys in the vault
    */
   async keys(): Promise<string[]> {
-    return this.vault.keys();
+    return this.vault.keys()
   }
 
   /**
    * Check if a key exists
    */
   async has(key: string): Promise<boolean> {
-    return this.vault.has(key);
+    return this.vault.has(key)
   }
 
   /**
    * Get vault configuration
    */
   getConfig(): SyncedVaultConfig {
-    return { ...this.config };
+    return { ...this.config }
   }
 
   /**
    * Start the sync engine (if not already running)
    */
   async startSync(): Promise<void> {
-    await this.sync.start();
+    await this.sync.start()
   }
 
   /**
    * Stop the sync engine
    */
   async stopSync(): Promise<void> {
-    await this.sync.stop();
+    await this.sync.stop()
   }
 
   /**
    * Trigger a manual sync
    */
   async syncNow(): Promise<Uint8Array> {
-    return this.sync.syncNow();
+    return this.sync.syncNow()
   }
 
   /**
    * Get the current sync status
    */
   getSyncStatus(): SyncStatus {
-    return this.sync.getStatus();
+    return this.sync.getStatus()
   }
 
   /**
    * Subscribe to sync events
    */
   onSyncEvent(listener: (event: SyncEvent) => void): () => void {
-    return this.sync.onEvent(listener);
+    return this.sync.onEvent(listener)
   }
 
   /**
    * Get sync updates since a state vector (for manual sync)
    */
   getUpdatesSince(stateVector: Uint8Array): Uint8Array {
-    return this.sync.getUpdatesSince(stateVector);
+    return this.sync.getUpdatesSince(stateVector)
   }
 
   /**
    * Apply a sync update from another peer
    */
   applyUpdate(update: Uint8Array, origin?: unknown): void {
-    this.sync.applyUpdate(update, origin);
+    this.sync.applyUpdate(update, origin)
   }
 
   /**
    * Get the current state vector (for sync negotiation)
    */
   getStateVector(): Uint8Array {
-    return this.sync.getStateVector();
+    return this.sync.getStateVector()
   }
 
   /**
    * Add a peer for syncing
    */
   async addPeer(endpoint: string): Promise<void> {
-    await this.sync.addPeer(endpoint);
+    await this.sync.addPeer(endpoint)
   }
 
   /**
    * Remove a peer
    */
   async removePeer(endpoint: string): Promise<void> {
-    await this.sync.removePeer(endpoint);
+    await this.sync.removePeer(endpoint)
   }
 
   /**
    * Get the underlying CRDT sync engine (for advanced use)
    */
   getCRDTSync(): CRDTSync {
-    return this.sync;
+    return this.sync
   }
 
   /**
@@ -260,10 +268,10 @@ export class SyncedVault {
    */
   async destroy(): Promise<void> {
     if (this.syncUnsubscribe) {
-      this.syncUnsubscribe();
-      this.syncUnsubscribe = null;
+      this.syncUnsubscribe()
+      this.syncUnsubscribe = null
     }
-    this.sync.destroy();
-    await this.vault.destroy();
+    this.sync.destroy()
+    await this.vault.destroy()
   }
 }

--- a/src/vault/types.ts
+++ b/src/vault/types.ts
@@ -4,72 +4,72 @@
 
 export interface ContextStoreConfig {
   /** Encryption configuration */
-  encryption?: EncryptionConfig;
+  encryption?: EncryptionConfig
   /** Sync configuration */
-  sync?: SyncConfig;
+  sync?: SyncConfig
   /** Storage path (for persistent storage) */
-  storagePath?: string;
+  storagePath?: string
 }
 
 export interface EncryptionConfig {
   /** Encryption algorithm (default: aes-256-gcm) */
-  algorithm?: "aes-256-gcm";
+  algorithm?: "aes-256-gcm"
   /** Key derivation function */
-  kdf?: "argon2id" | "pbkdf2";
+  kdf?: "argon2id" | "pbkdf2"
 }
 
 export interface VaultConfig {
   /** Vault name */
-  name: string;
+  name: string
   /** Optional description */
-  description?: string;
+  description?: string
   /** Schema version */
-  schemaVersion?: string;
+  schemaVersion?: string
   /** Encryption configuration */
-  encryption?: EncryptionConfig;
+  encryption?: EncryptionConfig
   /** Storage configuration */
-  storage?: StorageConfig;
+  storage?: StorageConfig
 }
 
 export interface StorageConfig {
   /** Storage type: memory (default) or sqlite */
-  type: "memory" | "sqlite";
+  type: "memory" | "sqlite"
   /** Path to SQLite database file (for sqlite storage) */
-  path?: string;
+  path?: string
 }
 
 export interface VaultData<T = unknown> {
   /** Unique identifier */
-  id: string;
+  id: string
   /** Data payload */
-  data: T;
+  data: T
   /** Creation timestamp */
-  createdAt: Date;
+  createdAt: Date
   /** Last update timestamp */
-  updatedAt: Date;
+  updatedAt: Date
   /** Version for conflict resolution */
-  version: number;
+  version: number
 }
 
 export interface SyncConfig {
   /** Sync mode */
-  mode: "realtime" | "periodic" | "manual";
+  mode: "realtime" | "periodic" | "manual"
   /** Peer endpoints for sync */
-  peers?: string[];
+  peers?: string[]
   /** Sync interval in milliseconds (for periodic mode) */
-  intervalMs?: number;
+  intervalMs?: number
 }
 
 export interface EmbeddingConfig {
   /** Embedding model to use */
-  model?: string;
+  model?: string
   /** Embedding dimensions */
-  dimensions?: number;
+  dimensions?: number
 }
 
 export interface SearchResult<T = unknown> {
   /** The matched data */
-  data: VaultData<T>;
+  data: VaultData<T>
   /** Similarity score (0-1) */
-  score: number;
+  score: number
 }

--- a/src/vectors/index.ts
+++ b/src/vectors/index.ts
@@ -5,55 +5,55 @@
  * Embeddings are stored alongside encrypted data for similarity search.
  */
 
-import Database from "better-sqlite3";
-import * as sqliteVec from "sqlite-vec";
+import Database from "better-sqlite3"
+import * as sqliteVec from "sqlite-vec"
 
 export interface VectorSearchResult {
   /** ID of the matched item */
-  id: string;
+  id: string
   /** Distance from query vector (lower = more similar) */
-  distance: number;
+  distance: number
   /** Any metadata stored with the vector */
-  metadata?: Record<string, unknown>;
+  metadata?: Record<string, unknown>
 }
 
 export interface VectorStoreOptions {
   /** Path to database file. Use ":memory:" for in-memory database */
-  path: string;
+  path: string
   /** Dimension of embedding vectors (e.g., 384 for all-MiniLM-L6-v2) */
-  dimensions: number;
+  dimensions: number
   /** Distance metric: "cosine" or "l2" (default: cosine) */
-  distanceMetric?: "cosine" | "l2";
+  distanceMetric?: "cosine" | "l2"
 }
 
 /**
  * Vector store for semantic similarity search using sqlite-vec
  */
 export class SQLiteVectorStore {
-  private db: Database.Database;
-  private dimensions: number;
+  private db: Database.Database
+  private dimensions: number
   private stmts!: {
-    insert: Database.Statement;
-    delete: Database.Statement;
-    search: Database.Statement;
-    get: Database.Statement;
-    count: Database.Statement;
-  };
+    insert: Database.Statement
+    delete: Database.Statement
+    search: Database.Statement
+    get: Database.Statement
+    count: Database.Statement
+  }
 
   constructor(options: VectorStoreOptions) {
-    this.dimensions = options.dimensions;
-    const distanceMetric = options.distanceMetric ?? "cosine";
+    this.dimensions = options.dimensions
+    const distanceMetric = options.distanceMetric ?? "cosine"
 
     // Open database and load sqlite-vec extension
-    this.db = new Database(options.path);
-    sqliteVec.load(this.db);
+    this.db = new Database(options.path)
+    sqliteVec.load(this.db)
 
     // Verify sqlite-vec is loaded
     const { version } = this.db
       .prepare("select vec_version() as version")
-      .get() as { version: string };
+      .get() as { version: string }
     if (!version) {
-      throw new Error("Failed to load sqlite-vec extension");
+      throw new Error("Failed to load sqlite-vec extension")
     }
 
     // Create virtual table for vector search
@@ -62,7 +62,7 @@ export class SQLiteVectorStore {
         item_id TEXT PRIMARY KEY,
         embedding float[${this.dimensions}] distance_metric=${distanceMetric}
       );
-    `);
+    `)
 
     // Create metadata table for storing additional info
     this.db.exec(`
@@ -72,10 +72,10 @@ export class SQLiteVectorStore {
         created_at TEXT NOT NULL,
         updated_at TEXT NOT NULL
       );
-    `);
+    `)
 
     // Prepare statements
-    this.prepareStatements();
+    this.prepareStatements()
   }
 
   private prepareStatements(): void {
@@ -102,7 +102,7 @@ export class SQLiteVectorStore {
       count: this.db.prepare(`
         SELECT COUNT(*) as count FROM vec_embeddings
       `),
-    };
+    }
   }
 
   /**
@@ -115,24 +115,24 @@ export class SQLiteVectorStore {
   async add(
     id: string,
     embedding: number[],
-    metadata?: Record<string, unknown>
+    metadata?: Record<string, unknown>,
   ): Promise<void> {
     if (embedding.length !== this.dimensions) {
       throw new Error(
-        `Embedding dimension mismatch: expected ${this.dimensions}, got ${embedding.length}`
-      );
+        `Embedding dimension mismatch: expected ${this.dimensions}, got ${embedding.length}`,
+      )
     }
 
-    const floatArray = new Float32Array(embedding);
-    const vectorBuffer = Buffer.from(floatArray.buffer);
-    const now = new Date().toISOString();
+    const floatArray = new Float32Array(embedding)
+    const vectorBuffer = Buffer.from(floatArray.buffer)
+    const now = new Date().toISOString()
 
     const transaction = this.db.transaction(() => {
       // Delete existing entry if it exists (vec0 doesn't support INSERT OR REPLACE)
-      this.stmts.delete.run(id);
+      this.stmts.delete.run(id)
 
       // Insert vector into vec0 virtual table
-      this.stmts.insert.run(id, vectorBuffer);
+      this.stmts.insert.run(id, vectorBuffer)
 
       // Insert or update metadata
       this.db
@@ -140,12 +140,12 @@ export class SQLiteVectorStore {
           `
         INSERT OR REPLACE INTO embedding_metadata (item_id, metadata, created_at, updated_at)
         VALUES (?, ?, COALESCE((SELECT created_at FROM embedding_metadata WHERE item_id = ?), ?), ?)
-      `
+      `,
         )
-        .run(id, metadata ? JSON.stringify(metadata) : null, id, now, now);
-    });
+        .run(id, metadata ? JSON.stringify(metadata) : null, id, now, now)
+    })
 
-    transaction();
+    transaction()
   }
 
   /**
@@ -157,26 +157,28 @@ export class SQLiteVectorStore {
    */
   async search(
     queryEmbedding: number[],
-    k: number = 10
+    k: number = 10,
   ): Promise<VectorSearchResult[]> {
     if (queryEmbedding.length !== this.dimensions) {
       throw new Error(
-        `Query embedding dimension mismatch: expected ${this.dimensions}, got ${queryEmbedding.length}`
-      );
+        `Query embedding dimension mismatch: expected ${this.dimensions}, got ${queryEmbedding.length}`,
+      )
     }
 
-    const floatArray = new Float32Array(queryEmbedding);
-    const vectorBuffer = Buffer.from(floatArray.buffer);
+    const floatArray = new Float32Array(queryEmbedding)
+    const vectorBuffer = Buffer.from(floatArray.buffer)
     const rows = this.stmts.search.all(vectorBuffer, k) as {
-      item_id: string;
-      distance: number;
-    }[];
+      item_id: string
+      distance: number
+    }[]
 
     return Promise.all(
       rows.map(async (row) => {
-        const metaRow = this.stmts.get.get(row.item_id) as {
-          metadata: string | null;
-        } | undefined;
+        const metaRow = this.stmts.get.get(row.item_id) as
+          | {
+              metadata: string | null
+            }
+          | undefined
 
         return {
           id: row.item_id,
@@ -184,9 +186,9 @@ export class SQLiteVectorStore {
           metadata: metaRow?.metadata
             ? JSON.parse(metaRow.metadata)
             : undefined,
-        };
-      })
-    );
+        }
+      }),
+    )
   }
 
   /**
@@ -194,28 +196,28 @@ export class SQLiteVectorStore {
    */
   async delete(id: string): Promise<boolean> {
     const transaction = this.db.transaction(() => {
-      const result = this.stmts.delete.run(id);
+      const result = this.stmts.delete.run(id)
       this.db
         .prepare("DELETE FROM embedding_metadata WHERE item_id = ?")
-        .run(id);
-      return result.changes > 0;
-    });
+        .run(id)
+      return result.changes > 0
+    })
 
-    return transaction();
+    return transaction()
   }
 
   /**
    * Get the total number of vectors stored
    */
   async count(): Promise<number> {
-    const result = this.stmts.count.get() as { count: number };
-    return result.count;
+    const result = this.stmts.count.get() as { count: number }
+    return result.count
   }
 
   /**
    * Close the database connection
    */
   close(): void {
-    this.db.close();
+    this.db.close()
   }
 }

--- a/tests/crdt-sync.test.ts
+++ b/tests/crdt-sync.test.ts
@@ -2,9 +2,13 @@
  * Tests for Yjs-based CRDT Sync Engine
  */
 
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { CRDTSync, type SyncedEntry, type SyncEvent } from "../src/sync/crdt-sync.js";
-import type { EncryptedData } from "../src/crypto/index.js";
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import type { EncryptedData } from "../src/crypto/index.js"
+import {
+  CRDTSync,
+  type SyncEvent,
+  type SyncedEntry,
+} from "../src/sync/crdt-sync.js"
 
 /** Helper to create mock encrypted data */
 function mockEncrypted(data: string): EncryptedData {
@@ -12,19 +16,19 @@ function mockEncrypted(data: string): EncryptedData {
     ciphertext: Buffer.from(data).toString("base64"),
     iv: Buffer.from("test-iv-12ch").toString("base64"),
     authTag: Buffer.from("test-auth-tag-16").toString("base64"),
-  };
+  }
 }
 
 describe("CRDTSync", () => {
-  let sync: CRDTSync;
+  let sync: CRDTSync
 
   beforeEach(() => {
-    sync = new CRDTSync({ mode: "manual" });
-  });
+    sync = new CRDTSync({ mode: "manual" })
+  })
 
   afterEach(() => {
-    sync.destroy();
-  });
+    sync.destroy()
+  })
 
   describe("basic operations", () => {
     it("should set and get entries", () => {
@@ -33,26 +37,26 @@ describe("CRDTSync", () => {
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
         version: 1,
-      };
+      }
 
-      sync.set("test-key", data);
-      const retrieved = sync.get("test-key");
+      sync.set("test-key", data)
+      const retrieved = sync.get("test-key")
 
-      expect(retrieved).toEqual(data);
-    });
+      expect(retrieved).toEqual(data)
+    })
 
     it("should check if key exists", () => {
-      expect(sync.has("nonexistent")).toBe(false);
+      expect(sync.has("nonexistent")).toBe(false)
 
       sync.set("exists", {
         encrypted: mockEncrypted("data"),
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
         version: 1,
-      });
+      })
 
-      expect(sync.has("exists")).toBe(true);
-    });
+      expect(sync.has("exists")).toBe(true)
+    })
 
     it("should list all keys", () => {
       sync.set("key1", {
@@ -60,19 +64,19 @@ describe("CRDTSync", () => {
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
         version: 1,
-      });
+      })
       sync.set("key2", {
         encrypted: mockEncrypted("data2"),
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
         version: 1,
-      });
+      })
 
-      const keys = sync.keys();
-      expect(keys).toContain("key1");
-      expect(keys).toContain("key2");
-      expect(keys.length).toBe(2);
-    });
+      const keys = sync.keys()
+      expect(keys).toContain("key1")
+      expect(keys).toContain("key2")
+      expect(keys.length).toBe(2)
+    })
 
     it("should remove entries", () => {
       sync.set("to-delete", {
@@ -80,29 +84,29 @@ describe("CRDTSync", () => {
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
         version: 1,
-      });
+      })
 
-      expect(sync.has("to-delete")).toBe(true);
-      const removed = sync.remove("to-delete");
-      expect(removed).toBe(true);
-      expect(sync.has("to-delete")).toBe(false);
-    });
+      expect(sync.has("to-delete")).toBe(true)
+      const removed = sync.remove("to-delete")
+      expect(removed).toBe(true)
+      expect(sync.has("to-delete")).toBe(false)
+    })
 
     it("should return false when removing nonexistent key", () => {
-      const removed = sync.remove("nonexistent");
-      expect(removed).toBe(false);
-    });
+      const removed = sync.remove("nonexistent")
+      expect(removed).toBe(false)
+    })
 
     it("should export entries as JSON", () => {
-      const encrypted = mockEncrypted("data1");
+      const encrypted = mockEncrypted("data1")
       sync.set("key1", {
         encrypted,
         createdAt: "2025-01-01T00:00:00Z",
         updatedAt: "2025-01-01T00:00:00Z",
         version: 1,
-      });
+      })
 
-      const json = sync.toJSON();
+      const json = sync.toJSON()
       expect(json).toEqual({
         key1: {
           encrypted,
@@ -110,8 +114,8 @@ describe("CRDTSync", () => {
           updatedAt: "2025-01-01T00:00:00Z",
           version: 1,
         },
-      });
-    });
+      })
+    })
 
     it("should import entries from object", () => {
       const data = {
@@ -127,21 +131,21 @@ describe("CRDTSync", () => {
           updatedAt: "2025-01-01T00:00:00Z",
           version: 2,
         },
-      };
+      }
 
-      sync.importEntries(data);
+      sync.importEntries(data)
 
-      expect(sync.get("imported1")).toEqual(data.imported1);
-      expect(sync.get("imported2")).toEqual(data.imported2);
-    });
-  });
+      expect(sync.get("imported1")).toEqual(data.imported1)
+      expect(sync.get("imported2")).toEqual(data.imported2)
+    })
+  })
 
   describe("CRDT sync between instances", () => {
     it("should sync changes between two instances via updates", () => {
-      const sync1 = new CRDTSync({ mode: "manual" });
-      const sync2 = new CRDTSync({ mode: "manual" });
+      const sync1 = new CRDTSync({ mode: "manual" })
+      const sync2 = new CRDTSync({ mode: "manual" })
 
-      const encrypted = mockEncrypted("sync1-data");
+      const encrypted = mockEncrypted("sync1-data")
 
       // Add data to sync1
       sync1.set("from-sync1", {
@@ -149,22 +153,22 @@ describe("CRDTSync", () => {
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
         version: 1,
-      });
+      })
 
       // Get update from sync1 and apply to sync2
-      const update = sync1.getUpdatesSince(sync2.getStateVector());
-      sync2.applyUpdate(update);
+      const update = sync1.getUpdatesSince(sync2.getStateVector())
+      sync2.applyUpdate(update)
 
       // sync2 should now have the data
-      expect(sync2.get("from-sync1")?.encrypted).toEqual(encrypted);
+      expect(sync2.get("from-sync1")?.encrypted).toEqual(encrypted)
 
-      sync1.destroy();
-      sync2.destroy();
-    });
+      sync1.destroy()
+      sync2.destroy()
+    })
 
     it("should handle concurrent updates (CRDT merge)", () => {
-      const sync1 = new CRDTSync({ mode: "manual" });
-      const sync2 = new CRDTSync({ mode: "manual" });
+      const sync1 = new CRDTSync({ mode: "manual" })
+      const sync2 = new CRDTSync({ mode: "manual" })
 
       // Both add different keys concurrently
       sync1.set("key-from-1", {
@@ -172,35 +176,35 @@ describe("CRDTSync", () => {
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
         version: 1,
-      });
+      })
 
       sync2.set("key-from-2", {
         encrypted: mockEncrypted("data2"),
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
         version: 1,
-      });
+      })
 
       // Exchange updates
-      const update1 = sync1.getUpdatesSince(sync2.getStateVector());
-      const update2 = sync2.getUpdatesSince(sync1.getStateVector());
+      const update1 = sync1.getUpdatesSince(sync2.getStateVector())
+      const update2 = sync2.getUpdatesSince(sync1.getStateVector())
 
-      sync2.applyUpdate(update1);
-      sync1.applyUpdate(update2);
+      sync2.applyUpdate(update1)
+      sync1.applyUpdate(update2)
 
       // Both should have both keys
-      expect(sync1.has("key-from-1")).toBe(true);
-      expect(sync1.has("key-from-2")).toBe(true);
-      expect(sync2.has("key-from-1")).toBe(true);
-      expect(sync2.has("key-from-2")).toBe(true);
+      expect(sync1.has("key-from-1")).toBe(true)
+      expect(sync1.has("key-from-2")).toBe(true)
+      expect(sync2.has("key-from-1")).toBe(true)
+      expect(sync2.has("key-from-2")).toBe(true)
 
-      sync1.destroy();
-      sync2.destroy();
-    });
+      sync1.destroy()
+      sync2.destroy()
+    })
 
     it("should handle concurrent edits to same key (last-write-wins for map)", () => {
-      const sync1 = new CRDTSync({ mode: "manual" });
-      const sync2 = new CRDTSync({ mode: "manual" });
+      const sync1 = new CRDTSync({ mode: "manual" })
+      const sync2 = new CRDTSync({ mode: "manual" })
 
       // Start with same initial state
       const initial = {
@@ -208,56 +212,58 @@ describe("CRDTSync", () => {
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
         version: 1,
-      };
-      sync1.set("shared-key", initial);
+      }
+      sync1.set("shared-key", initial)
 
       // Sync to sync2
-      sync2.applyUpdate(sync1.getUpdatesSince(sync2.getStateVector()));
+      sync2.applyUpdate(sync1.getUpdatesSince(sync2.getStateVector()))
 
       // Both edit the same key concurrently
       sync1.set("shared-key", {
         ...initial,
         encrypted: mockEncrypted("edit-from-1"),
         version: 2,
-      });
+      })
 
       sync2.set("shared-key", {
         ...initial,
         encrypted: mockEncrypted("edit-from-2"),
         version: 2,
-      });
+      })
 
       // Exchange updates
-      const update1 = sync1.getUpdatesSince(sync2.getStateVector());
-      const update2 = sync2.getUpdatesSince(sync1.getStateVector());
+      const update1 = sync1.getUpdatesSince(sync2.getStateVector())
+      const update2 = sync2.getUpdatesSince(sync1.getStateVector())
 
-      sync2.applyUpdate(update1);
-      sync1.applyUpdate(update2);
+      sync2.applyUpdate(update1)
+      sync1.applyUpdate(update2)
 
       // Both should converge to the same value (Yjs Y.Map uses LWW)
-      expect(sync1.get("shared-key")?.encrypted).toEqual(sync2.get("shared-key")?.encrypted);
+      expect(sync1.get("shared-key")?.encrypted).toEqual(
+        sync2.get("shared-key")?.encrypted,
+      )
 
-      sync1.destroy();
-      sync2.destroy();
-    });
-  });
+      sync1.destroy()
+      sync2.destroy()
+    })
+  })
 
   describe("event handling", () => {
     it("should emit events on changes", async () => {
-      const events: SyncEvent[] = [];
-      sync.onEvent((event) => events.push(event));
+      const events: SyncEvent[] = []
+      sync.onEvent((event) => events.push(event))
 
-      await sync.start();
+      await sync.start()
 
-      expect(events.some((e) => e.type === "sync_start")).toBe(true);
-    });
+      expect(events.some((e) => e.type === "sync_start")).toBe(true)
+    })
 
     it("should emit update events for remote changes", () => {
-      const sync1 = new CRDTSync({ mode: "manual" });
-      const sync2 = new CRDTSync({ mode: "manual" });
+      const sync1 = new CRDTSync({ mode: "manual" })
+      const sync2 = new CRDTSync({ mode: "manual" })
 
-      const events: SyncEvent[] = [];
-      sync2.onEvent((event) => events.push(event));
+      const events: SyncEvent[] = []
+      sync2.onEvent((event) => events.push(event))
 
       // Make a change in sync1
       sync1.set("remote-change", {
@@ -265,48 +271,48 @@ describe("CRDTSync", () => {
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
         version: 1,
-      });
+      })
 
       // Apply to sync2 (simulating remote update)
-      sync2.applyUpdate(sync1.getUpdatesSince(sync2.getStateVector()), "remote");
+      sync2.applyUpdate(sync1.getUpdatesSince(sync2.getStateVector()), "remote")
 
       // Should have received an update event
-      expect(events.some((e) => e.type === "update")).toBe(true);
+      expect(events.some((e) => e.type === "update")).toBe(true)
 
-      sync1.destroy();
-      sync2.destroy();
-    });
+      sync1.destroy()
+      sync2.destroy()
+    })
 
     it("should allow unsubscribing from events", () => {
-      const events: SyncEvent[] = [];
-      const unsubscribe = sync.onEvent((event) => events.push(event));
+      const events: SyncEvent[] = []
+      const unsubscribe = sync.onEvent((event) => events.push(event))
 
-      unsubscribe();
+      unsubscribe()
 
       sync.set("test", {
         encrypted: mockEncrypted("data"),
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
         version: 1,
-      });
+      })
 
       // No events should be captured after unsubscribe
       // (set doesn't emit events, but this tests the unsubscribe mechanism)
-      expect(events.length).toBe(0);
-    });
-  });
+      expect(events.length).toBe(0)
+    })
+  })
 
   describe("status", () => {
     it("should start with idle status", () => {
-      expect(sync.getStatus()).toBe("idle");
-    });
+      expect(sync.getStatus()).toBe("idle")
+    })
 
     it("should update status during sync", async () => {
-      await sync.syncNow();
+      await sync.syncNow()
       // After sync completes, status should return to idle (no WS provider)
-      expect(sync.getStatus()).toBe("idle");
-    });
-  });
+      expect(sync.getStatus()).toBe("idle")
+    })
+  })
 
   describe("manual sync", () => {
     it("should return state update on syncNow", async () => {
@@ -315,11 +321,11 @@ describe("CRDTSync", () => {
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
         version: 1,
-      });
+      })
 
-      const update = await sync.syncNow();
-      expect(update).toBeInstanceOf(Uint8Array);
-      expect(update.length).toBeGreaterThan(0);
-    });
-  });
-});
+      const update = await sync.syncNow()
+      expect(update).toBeInstanceOf(Uint8Array)
+      expect(update.length).toBeGreaterThan(0)
+    })
+  })
+})

--- a/tests/crypto.test.ts
+++ b/tests/crypto.test.ts
@@ -1,193 +1,191 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest"
 import {
-  encrypt,
-  decrypt,
-  encryptWithPassword,
-  decryptWithPassword,
-  generateKey,
-  deriveKey,
   clearKey,
-} from "../src/crypto/index.js";
+  decrypt,
+  decryptWithPassword,
+  deriveKey,
+  encrypt,
+  encryptWithPassword,
+  generateKey,
+} from "../src/crypto/index.js"
 
 describe("Crypto", () => {
   describe("key generation", () => {
     it("should generate a 32-byte key", () => {
-      const key = generateKey();
-      expect(key.length).toBe(32);
-    });
+      const key = generateKey()
+      expect(key.length).toBe(32)
+    })
 
     it("should generate unique keys", () => {
-      const key1 = generateKey();
-      const key2 = generateKey();
-      expect(key1.equals(key2)).toBe(false);
-    });
-  });
+      const key1 = generateKey()
+      const key2 = generateKey()
+      expect(key1.equals(key2)).toBe(false)
+    })
+  })
 
   describe("key derivation", () => {
     it("should derive consistent key from password", () => {
-      const { key: key1, salt } = deriveKey("test-password");
-      const { key: key2 } = deriveKey("test-password", salt);
-      expect(key1.equals(key2)).toBe(true);
-    });
+      const { key: key1, salt } = deriveKey("test-password")
+      const { key: key2 } = deriveKey("test-password", salt)
+      expect(key1.equals(key2)).toBe(true)
+    })
 
     it("should derive different keys for different passwords", () => {
-      const { key: key1, salt } = deriveKey("password1");
-      const { key: key2 } = deriveKey("password2", salt);
-      expect(key1.equals(key2)).toBe(false);
-    });
+      const { key: key1, salt } = deriveKey("password1")
+      const { key: key2 } = deriveKey("password2", salt)
+      expect(key1.equals(key2)).toBe(false)
+    })
 
     it("should derive different keys with different salts", () => {
-      const { key: key1 } = deriveKey("same-password");
-      const { key: key2 } = deriveKey("same-password");
+      const { key: key1 } = deriveKey("same-password")
+      const { key: key2 } = deriveKey("same-password")
       // Different salts = different keys
-      expect(key1.equals(key2)).toBe(false);
-    });
-  });
+      expect(key1.equals(key2)).toBe(false)
+    })
+  })
 
   describe("encrypt/decrypt", () => {
     it("should encrypt and decrypt a string", () => {
-      const key = generateKey();
-      const plaintext = "Hello, World!";
+      const key = generateKey()
+      const plaintext = "Hello, World!"
 
-      const encrypted = encrypt(plaintext, key);
-      expect(encrypted.ciphertext).not.toBe(plaintext);
-      expect(encrypted.iv).toBeDefined();
-      expect(encrypted.authTag).toBeDefined();
+      const encrypted = encrypt(plaintext, key)
+      expect(encrypted.ciphertext).not.toBe(plaintext)
+      expect(encrypted.iv).toBeDefined()
+      expect(encrypted.authTag).toBeDefined()
 
-      const decrypted = decrypt(encrypted, key);
-      expect(decrypted).toBe(plaintext);
-    });
+      const decrypted = decrypt(encrypted, key)
+      expect(decrypted).toBe(plaintext)
+    })
 
     it("should encrypt and decrypt JSON data", () => {
-      const key = generateKey();
-      const data = { name: "Alice", age: 30, nested: { value: true } };
-      const plaintext = JSON.stringify(data);
+      const key = generateKey()
+      const data = { name: "Alice", age: 30, nested: { value: true } }
+      const plaintext = JSON.stringify(data)
 
-      const encrypted = encrypt(plaintext, key);
-      const decrypted = decrypt(encrypted, key);
+      const encrypted = encrypt(plaintext, key)
+      const decrypted = decrypt(encrypted, key)
 
-      expect(JSON.parse(decrypted)).toEqual(data);
-    });
+      expect(JSON.parse(decrypted)).toEqual(data)
+    })
 
     it("should encrypt and decrypt a Buffer", () => {
-      const key = generateKey();
+      const key = generateKey()
       // Use valid UTF-8 bytes for round-trip test
-      const originalText = "Binary test: \u0000\u0001\u0002";
-      const buffer = Buffer.from(originalText, "utf8");
+      const originalText = "Binary test: \u0000\u0001\u0002"
+      const buffer = Buffer.from(originalText, "utf8")
 
-      const encrypted = encrypt(buffer, key);
-      const decrypted = decrypt(encrypted, key);
+      const encrypted = encrypt(buffer, key)
+      const decrypted = decrypt(encrypted, key)
 
-      expect(decrypted).toBe(originalText);
-    });
+      expect(decrypted).toBe(originalText)
+    })
 
     it("should produce different ciphertext for same plaintext", () => {
-      const key = generateKey();
-      const plaintext = "Same message";
+      const key = generateKey()
+      const plaintext = "Same message"
 
-      const encrypted1 = encrypt(plaintext, key);
-      const encrypted2 = encrypt(plaintext, key);
+      const encrypted1 = encrypt(plaintext, key)
+      const encrypted2 = encrypt(plaintext, key)
 
       // IVs should be different
-      expect(encrypted1.iv).not.toBe(encrypted2.iv);
+      expect(encrypted1.iv).not.toBe(encrypted2.iv)
       // Ciphertext should be different due to different IVs
-      expect(encrypted1.ciphertext).not.toBe(encrypted2.ciphertext);
-    });
+      expect(encrypted1.ciphertext).not.toBe(encrypted2.ciphertext)
+    })
 
     it("should fail decryption with wrong key", () => {
-      const key1 = generateKey();
-      const key2 = generateKey();
-      const plaintext = "Secret message";
+      const key1 = generateKey()
+      const key2 = generateKey()
+      const plaintext = "Secret message"
 
-      const encrypted = encrypt(plaintext, key1);
+      const encrypted = encrypt(plaintext, key1)
 
       expect(() => decrypt(encrypted, key2)).toThrow(
-        "Decryption failed: invalid key or tampered data"
-      );
-    });
+        "Decryption failed: invalid key or tampered data",
+      )
+    })
 
     it("should fail decryption with tampered ciphertext", () => {
-      const key = generateKey();
-      const plaintext = "Secret message";
+      const key = generateKey()
+      const plaintext = "Secret message"
 
-      const encrypted = encrypt(plaintext, key);
+      const encrypted = encrypt(plaintext, key)
       // Tamper with the ciphertext
-      const tampered = Buffer.from(encrypted.ciphertext, "base64");
-      tampered[0] ^= 0xff;
-      encrypted.ciphertext = tampered.toString("base64");
+      const tampered = Buffer.from(encrypted.ciphertext, "base64")
+      tampered[0] ^= 0xff
+      encrypted.ciphertext = tampered.toString("base64")
 
       expect(() => decrypt(encrypted, key)).toThrow(
-        "Decryption failed: invalid key or tampered data"
-      );
-    });
+        "Decryption failed: invalid key or tampered data",
+      )
+    })
 
     it("should fail decryption with tampered auth tag", () => {
-      const key = generateKey();
-      const plaintext = "Secret message";
+      const key = generateKey()
+      const plaintext = "Secret message"
 
-      const encrypted = encrypt(plaintext, key);
+      const encrypted = encrypt(plaintext, key)
       // Tamper with the auth tag
-      const tampered = Buffer.from(encrypted.authTag, "base64");
-      tampered[0] ^= 0xff;
-      encrypted.authTag = tampered.toString("base64");
+      const tampered = Buffer.from(encrypted.authTag, "base64")
+      tampered[0] ^= 0xff
+      encrypted.authTag = tampered.toString("base64")
 
       expect(() => decrypt(encrypted, key)).toThrow(
-        "Decryption failed: invalid key or tampered data"
-      );
-    });
+        "Decryption failed: invalid key or tampered data",
+      )
+    })
 
     it("should reject invalid key length", () => {
-      const shortKey = Buffer.alloc(16);
-      const plaintext = "Test";
+      const shortKey = Buffer.alloc(16)
+      const plaintext = "Test"
 
-      expect(() => encrypt(plaintext, shortKey)).toThrow(
-        "Key must be 32 bytes"
-      );
-    });
-  });
+      expect(() => encrypt(plaintext, shortKey)).toThrow("Key must be 32 bytes")
+    })
+  })
 
   describe("password-based encryption", () => {
     it("should encrypt and decrypt with password", () => {
-      const password = "my-secret-password";
-      const plaintext = "Sensitive data";
+      const password = "my-secret-password"
+      const plaintext = "Sensitive data"
 
-      const encrypted = encryptWithPassword(plaintext, password);
-      expect(encrypted.salt).toBeDefined();
+      const encrypted = encryptWithPassword(plaintext, password)
+      expect(encrypted.salt).toBeDefined()
 
-      const decrypted = decryptWithPassword(encrypted, password);
-      expect(decrypted).toBe(plaintext);
-    });
+      const decrypted = decryptWithPassword(encrypted, password)
+      expect(decrypted).toBe(plaintext)
+    })
 
     it("should fail with wrong password", () => {
-      const plaintext = "Sensitive data";
+      const plaintext = "Sensitive data"
 
-      const encrypted = encryptWithPassword(plaintext, "correct-password");
+      const encrypted = encryptWithPassword(plaintext, "correct-password")
 
       expect(() => decryptWithPassword(encrypted, "wrong-password")).toThrow(
-        "Decryption failed"
-      );
-    });
+        "Decryption failed",
+      )
+    })
 
     it("should fail if salt is missing", () => {
-      const encrypted = encryptWithPassword("test", "password");
-      delete encrypted.salt;
+      const encrypted = encryptWithPassword("test", "password")
+      delete encrypted.salt
 
       expect(() => decryptWithPassword(encrypted, "password")).toThrow(
-        "No salt found"
-      );
-    });
-  });
+        "No salt found",
+      )
+    })
+  })
 
   describe("clearKey", () => {
     it("should zero out the key buffer", () => {
-      const key = generateKey();
+      const key = generateKey()
       // Verify key has non-zero bytes
-      expect(key.some((b) => b !== 0)).toBe(true);
+      expect(key.some((b) => b !== 0)).toBe(true)
 
-      clearKey(key);
+      clearKey(key)
 
       // All bytes should now be zero
-      expect(key.every((b) => b === 0)).toBe(true);
-    });
-  });
-});
+      expect(key.every((b) => b === 0)).toBe(true)
+    })
+  })
+})

--- a/tests/sqlite.test.ts
+++ b/tests/sqlite.test.ts
@@ -1,141 +1,141 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { SQLiteStorage } from "../src/storage/sqlite.js";
-import { EncryptedVault } from "../src/vault/encrypted-vault.js";
-import { encrypt, generateKey } from "../src/crypto/index.js";
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { encrypt, generateKey } from "../src/crypto/index.js"
+import { SQLiteStorage } from "../src/storage/sqlite.js"
+import { EncryptedVault } from "../src/vault/encrypted-vault.js"
 
 describe("SQLiteStorage", () => {
-  let storage: SQLiteStorage;
+  let storage: SQLiteStorage
 
   beforeEach(() => {
     storage = new SQLiteStorage({
       path: ":memory:",
       vaultName: "test-vault",
-    });
-  });
+    })
+  })
 
   afterEach(() => {
-    storage.close();
-  });
+    storage.close()
+  })
 
   it("should store and retrieve entries", () => {
-    const key = generateKey();
-    const encrypted = encrypt("test data", key);
+    const key = generateKey()
+    const encrypted = encrypt("test data", key)
     const entry = {
       encrypted,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
       version: 1,
-    };
+    }
 
-    storage.put("key1", entry);
-    const retrieved = storage.get("key1");
+    storage.put("key1", entry)
+    const retrieved = storage.get("key1")
 
-    expect(retrieved).toBeDefined();
-    expect(retrieved?.encrypted.ciphertext).toBe(encrypted.ciphertext);
-    expect(retrieved?.version).toBe(1);
-  });
+    expect(retrieved).toBeDefined()
+    expect(retrieved?.encrypted.ciphertext).toBe(encrypted.ciphertext)
+    expect(retrieved?.version).toBe(1)
+  })
 
   it("should return undefined for missing keys", () => {
-    expect(storage.get("nonexistent")).toBeUndefined();
-  });
+    expect(storage.get("nonexistent")).toBeUndefined()
+  })
 
   it("should delete entries", () => {
-    const key = generateKey();
-    const encrypted = encrypt("test", key);
+    const key = generateKey()
+    const encrypted = encrypt("test", key)
     storage.put("key1", {
       encrypted,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
       version: 1,
-    });
+    })
 
-    expect(storage.has("key1")).toBe(true);
-    expect(storage.delete("key1")).toBe(true);
-    expect(storage.has("key1")).toBe(false);
-    expect(storage.delete("key1")).toBe(false);
-  });
+    expect(storage.has("key1")).toBe(true)
+    expect(storage.delete("key1")).toBe(true)
+    expect(storage.has("key1")).toBe(false)
+    expect(storage.delete("key1")).toBe(false)
+  })
 
   it("should list all keys", () => {
-    const key = generateKey();
+    const key = generateKey()
 
     storage.put("a", {
       encrypted: encrypt("a", key),
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
       version: 1,
-    });
+    })
     storage.put("b", {
       encrypted: encrypt("b", key),
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
       version: 1,
-    });
+    })
     storage.put("c", {
       encrypted: encrypt("c", key),
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
       version: 1,
-    });
+    })
 
-    const keys = storage.keys();
-    expect(keys).toHaveLength(3);
-    expect(keys).toContain("a");
-    expect(keys).toContain("b");
-    expect(keys).toContain("c");
-  });
+    const keys = storage.keys()
+    expect(keys).toHaveLength(3)
+    expect(keys).toContain("a")
+    expect(keys).toContain("b")
+    expect(keys).toContain("c")
+  })
 
   it("should export and import all entries", () => {
-    const key = generateKey();
+    const key = generateKey()
 
     storage.put("x", {
       encrypted: encrypt("x-data", key),
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
       version: 1,
-    });
+    })
     storage.put("y", {
       encrypted: encrypt("y-data", key),
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
       version: 2,
-    });
+    })
 
-    const exported = storage.getAll();
-    expect(Object.keys(exported)).toHaveLength(2);
+    const exported = storage.getAll()
+    expect(Object.keys(exported)).toHaveLength(2)
 
     // Clear and reimport
-    storage.clear();
-    expect(storage.keys()).toHaveLength(0);
+    storage.clear()
+    expect(storage.keys()).toHaveLength(0)
 
-    storage.importAll(exported);
-    expect(storage.keys()).toHaveLength(2);
-    expect(storage.get("x")?.version).toBe(1);
-    expect(storage.get("y")?.version).toBe(2);
-  });
+    storage.importAll(exported)
+    expect(storage.keys()).toHaveLength(2)
+    expect(storage.get("x")?.version).toBe(1)
+    expect(storage.get("y")?.version).toBe(2)
+  })
 
   it("should isolate data between vault names", () => {
-    const key = generateKey();
+    const key = generateKey()
     storage.put("shared-key", {
       encrypted: encrypt("vault1-data", key),
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
       version: 1,
-    });
+    })
 
     // Create another storage with different vault name using same DB path
     const storage2 = new SQLiteStorage({
       path: ":memory:",
       vaultName: "other-vault",
-    });
+    })
 
     // The new storage shouldn't see the data from vault1
-    expect(storage2.get("shared-key")).toBeUndefined();
-    storage2.close();
-  });
-});
+    expect(storage2.get("shared-key")).toBeUndefined()
+    storage2.close()
+  })
+})
 
 describe("EncryptedVault with SQLite", () => {
-  let vault: EncryptedVault;
+  let vault: EncryptedVault
 
   beforeEach(async () => {
     vault = new EncryptedVault({
@@ -144,37 +144,37 @@ describe("EncryptedVault with SQLite", () => {
         type: "sqlite",
         path: ":memory:",
       },
-    });
-    await vault.initialize();
-  });
+    })
+    await vault.initialize()
+  })
 
   afterEach(async () => {
-    await vault.destroy();
-  });
+    await vault.destroy()
+  })
 
   it("should store and retrieve encrypted data using SQLite", async () => {
-    const data = { name: "test", value: 42 };
-    await vault.put("test-key", data);
+    const data = { name: "test", value: 42 }
+    await vault.put("test-key", data)
 
-    const retrieved = await vault.get<typeof data>("test-key");
-    expect(retrieved?.data).toEqual(data);
-  });
+    const retrieved = await vault.get<typeof data>("test-key")
+    expect(retrieved?.data).toEqual(data)
+  })
 
   it("should persist across operations", async () => {
-    await vault.put("persistent", { foo: "bar" });
-    await vault.put("another", { baz: 123 });
+    await vault.put("persistent", { foo: "bar" })
+    await vault.put("another", { baz: 123 })
 
-    const keys = await vault.keys();
-    expect(keys).toHaveLength(2);
-    expect(keys).toContain("persistent");
-    expect(keys).toContain("another");
-  });
+    const keys = await vault.keys()
+    expect(keys).toHaveLength(2)
+    expect(keys).toContain("persistent")
+    expect(keys).toContain("another")
+  })
 
   it("should support export and import with SQLite backend", async () => {
-    await vault.put("item1", { a: 1 });
-    await vault.put("item2", { b: 2 });
+    await vault.put("item1", { a: 1 })
+    await vault.put("item2", { b: 2 })
 
-    const exported = await vault.export();
-    expect(Object.keys(exported)).toHaveLength(2);
-  });
-});
+    const exported = await vault.export()
+    expect(Object.keys(exported)).toHaveLength(2)
+  })
+})

--- a/tests/synced-vault.test.ts
+++ b/tests/synced-vault.test.ts
@@ -2,59 +2,59 @@
  * Tests for SyncedVault - EncryptedVault with CRDT sync
  */
 
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { SyncedVault } from "../src/vault/synced-vault.js";
-import type { SyncEvent } from "../src/sync/crdt-sync.js";
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import type { SyncEvent } from "../src/sync/crdt-sync.js"
+import { SyncedVault } from "../src/vault/synced-vault.js"
 
 describe("SyncedVault", () => {
-  let vault: SyncedVault;
+  let vault: SyncedVault
 
   beforeEach(async () => {
     vault = new SyncedVault({
       name: "test-synced-vault",
       storage: { type: "memory" },
       sync: { mode: "manual" },
-    });
-    await vault.initialize();
-  });
+    })
+    await vault.initialize()
+  })
 
   afterEach(async () => {
-    await vault.destroy();
-  });
+    await vault.destroy()
+  })
 
   describe("basic vault operations", () => {
     it("should store and retrieve data", async () => {
-      await vault.put("test-key", { message: "hello world" });
-      const result = await vault.get<{ message: string }>("test-key");
+      await vault.put("test-key", { message: "hello world" })
+      const result = await vault.get<{ message: string }>("test-key")
 
-      expect(result?.data.message).toBe("hello world");
-    });
+      expect(result?.data.message).toBe("hello world")
+    })
 
     it("should check if key exists", async () => {
-      expect(await vault.has("missing")).toBe(false);
+      expect(await vault.has("missing")).toBe(false)
 
-      await vault.put("exists", { value: 1 });
-      expect(await vault.has("exists")).toBe(true);
-    });
+      await vault.put("exists", { value: 1 })
+      expect(await vault.has("exists")).toBe(true)
+    })
 
     it("should list all keys", async () => {
-      await vault.put("key1", { a: 1 });
-      await vault.put("key2", { b: 2 });
+      await vault.put("key1", { a: 1 })
+      await vault.put("key2", { b: 2 })
 
-      const keys = await vault.keys();
-      expect(keys).toContain("key1");
-      expect(keys).toContain("key2");
-    });
+      const keys = await vault.keys()
+      expect(keys).toContain("key1")
+      expect(keys).toContain("key2")
+    })
 
     it("should delete entries", async () => {
-      await vault.put("to-delete", { value: "bye" });
-      expect(await vault.has("to-delete")).toBe(true);
+      await vault.put("to-delete", { value: "bye" })
+      expect(await vault.has("to-delete")).toBe(true)
 
-      const deleted = await vault.delete("to-delete");
-      expect(deleted).toBe(true);
-      expect(await vault.has("to-delete")).toBe(false);
-    });
-  });
+      const deleted = await vault.delete("to-delete")
+      expect(deleted).toBe(true)
+      expect(await vault.has("to-delete")).toBe(false)
+    })
+  })
 
   describe("initialization methods", () => {
     it("should initialize with password", async () => {
@@ -62,35 +62,35 @@ describe("SyncedVault", () => {
         name: "password-vault",
         storage: { type: "memory" },
         sync: { mode: "manual" },
-      });
+      })
 
-      await passwordVault.initializeWithPassword("test-password-123");
+      await passwordVault.initializeWithPassword("test-password-123")
 
-      await passwordVault.put("secret", { data: "encrypted-with-password" });
-      const result = await passwordVault.get<{ data: string }>("secret");
-      expect(result?.data.data).toBe("encrypted-with-password");
+      await passwordVault.put("secret", { data: "encrypted-with-password" })
+      const result = await passwordVault.get<{ data: string }>("secret")
+      expect(result?.data.data).toBe("encrypted-with-password")
 
-      await passwordVault.destroy();
-    });
+      await passwordVault.destroy()
+    })
 
     it("should initialize with key", async () => {
-      const key = Buffer.alloc(32, "a"); // 32 bytes for AES-256
+      const key = Buffer.alloc(32, "a") // 32 bytes for AES-256
 
       const keyVault = new SyncedVault({
         name: "key-vault",
         storage: { type: "memory" },
         sync: { mode: "manual" },
-      });
+      })
 
-      await keyVault.initializeWithKey(key);
+      await keyVault.initializeWithKey(key)
 
-      await keyVault.put("data", { value: 42 });
-      const result = await keyVault.get<{ value: number }>("data");
-      expect(result?.data.value).toBe(42);
+      await keyVault.put("data", { value: 42 })
+      const result = await keyVault.get<{ value: number }>("data")
+      expect(result?.data.value).toBe(42)
 
-      await keyVault.destroy();
-    });
-  });
+      await keyVault.destroy()
+    })
+  })
 
   describe("sync operations", () => {
     it("should sync between two vaults", async () => {
@@ -98,108 +98,108 @@ describe("SyncedVault", () => {
         name: "vault1",
         storage: { type: "memory" },
         sync: { mode: "manual" },
-      });
+      })
       const vault2 = new SyncedVault({
         name: "vault2",
         storage: { type: "memory" },
         sync: { mode: "manual" },
-      });
+      })
 
       // Use same key for both vaults
-      const sharedKey = Buffer.alloc(32, "shared-key");
-      await vault1.initializeWithKey(sharedKey);
-      await vault2.initializeWithKey(sharedKey);
+      const sharedKey = Buffer.alloc(32, "shared-key")
+      await vault1.initializeWithKey(sharedKey)
+      await vault2.initializeWithKey(sharedKey)
 
       // Add data to vault1
-      await vault1.put("from-vault1", { origin: "vault1" });
+      await vault1.put("from-vault1", { origin: "vault1" })
 
       // Sync vault1 -> vault2
-      const update = vault1.getUpdatesSince(vault2.getStateVector());
-      vault2.applyUpdate(update);
+      const update = vault1.getUpdatesSince(vault2.getStateVector())
+      vault2.applyUpdate(update)
 
       // vault2 should now have the data
-      const result = await vault2.get<{ origin: string }>("from-vault1");
-      expect(result?.data.origin).toBe("vault1");
+      const result = await vault2.get<{ origin: string }>("from-vault1")
+      expect(result?.data.origin).toBe("vault1")
 
-      await vault1.destroy();
-      await vault2.destroy();
-    });
+      await vault1.destroy()
+      await vault2.destroy()
+    })
 
     it("should handle bidirectional sync", async () => {
       const vault1 = new SyncedVault({
         name: "vault1",
         storage: { type: "memory" },
         sync: { mode: "manual" },
-      });
+      })
       const vault2 = new SyncedVault({
         name: "vault2",
         storage: { type: "memory" },
         sync: { mode: "manual" },
-      });
+      })
 
-      const sharedKey = Buffer.alloc(32, "shared-key");
-      await vault1.initializeWithKey(sharedKey);
-      await vault2.initializeWithKey(sharedKey);
+      const sharedKey = Buffer.alloc(32, "shared-key")
+      await vault1.initializeWithKey(sharedKey)
+      await vault2.initializeWithKey(sharedKey)
 
       // Add data to both vaults
-      await vault1.put("from-v1", { source: 1 });
-      await vault2.put("from-v2", { source: 2 });
+      await vault1.put("from-v1", { source: 1 })
+      await vault2.put("from-v2", { source: 2 })
 
       // Exchange updates
-      const update1 = vault1.getUpdatesSince(vault2.getStateVector());
-      const update2 = vault2.getUpdatesSince(vault1.getStateVector());
+      const update1 = vault1.getUpdatesSince(vault2.getStateVector())
+      const update2 = vault2.getUpdatesSince(vault1.getStateVector())
 
-      vault2.applyUpdate(update1);
-      vault1.applyUpdate(update2);
+      vault2.applyUpdate(update1)
+      vault1.applyUpdate(update2)
 
       // Both should have both entries
-      expect(await vault1.has("from-v1")).toBe(true);
-      expect(await vault1.has("from-v2")).toBe(true);
-      expect(await vault2.has("from-v1")).toBe(true);
-      expect(await vault2.has("from-v2")).toBe(true);
+      expect(await vault1.has("from-v1")).toBe(true)
+      expect(await vault1.has("from-v2")).toBe(true)
+      expect(await vault2.has("from-v1")).toBe(true)
+      expect(await vault2.has("from-v2")).toBe(true)
 
-      await vault1.destroy();
-      await vault2.destroy();
-    });
+      await vault1.destroy()
+      await vault2.destroy()
+    })
 
     it("should track sync status", async () => {
-      expect(vault.getSyncStatus()).toBe("idle");
+      expect(vault.getSyncStatus()).toBe("idle")
 
-      await vault.syncNow();
-      expect(vault.getSyncStatus()).toBe("idle"); // Returns to idle after manual sync
-    });
+      await vault.syncNow()
+      expect(vault.getSyncStatus()).toBe("idle") // Returns to idle after manual sync
+    })
 
     it("should emit sync events", async () => {
-      const events: SyncEvent[] = [];
-      vault.onSyncEvent((event) => events.push(event));
+      const events: SyncEvent[] = []
+      vault.onSyncEvent((event) => events.push(event))
 
-      await vault.startSync();
+      await vault.startSync()
 
-      expect(events.some((e) => e.type === "sync_start")).toBe(true);
-    });
+      expect(events.some((e) => e.type === "sync_start")).toBe(true)
+    })
 
     it("should return state update on syncNow", async () => {
-      await vault.put("test", { value: 123 });
+      await vault.put("test", { value: 123 })
 
-      const update = await vault.syncNow();
-      expect(update).toBeInstanceOf(Uint8Array);
-      expect(update.length).toBeGreaterThan(0);
-    });
-  });
+      const update = await vault.syncNow()
+      expect(update).toBeInstanceOf(Uint8Array)
+      expect(update.length).toBeGreaterThan(0)
+    })
+  })
 
   describe("config", () => {
     it("should return vault configuration", () => {
-      const config = vault.getConfig();
-      expect(config.name).toBe("test-synced-vault");
-      expect(config.sync?.mode).toBe("manual");
-    });
-  });
+      const config = vault.getConfig()
+      expect(config.name).toBe("test-synced-vault")
+      expect(config.sync?.mode).toBe("manual")
+    })
+  })
 
   describe("CRDT access", () => {
     it("should expose underlying CRDT sync engine", () => {
-      const crdt = vault.getCRDTSync();
-      expect(crdt).toBeDefined();
-      expect(typeof crdt.getStateVector).toBe("function");
-    });
-  });
-});
+      const crdt = vault.getCRDTSync()
+      expect(crdt).toBeDefined()
+      expect(typeof crdt.getStateVector).toBe("function")
+    })
+  })
+})

--- a/tests/vault.test.ts
+++ b/tests/vault.test.ts
@@ -1,103 +1,105 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import { ContextStore } from "../src/vault/context-store.js";
+import { beforeEach, describe, expect, it } from "vitest"
+import { ContextStore } from "../src/vault/context-store.js"
 
 describe("ContextStore", () => {
-  let store: ContextStore;
+  let store: ContextStore
 
   beforeEach(() => {
-    store = new ContextStore();
-  });
+    store = new ContextStore()
+  })
 
   describe("vault management", () => {
     it("should create a new vault", async () => {
-      const vault = await store.createVault("test");
-      expect(vault).toBeDefined();
-      expect(vault.getConfig().name).toBe("test");
-    });
+      const vault = await store.createVault("test")
+      expect(vault).toBeDefined()
+      expect(vault.getConfig().name).toBe("test")
+    })
 
     it("should not allow duplicate vault names", async () => {
-      await store.createVault("test");
-      await expect(store.createVault("test")).rejects.toThrow('Vault "test" already exists');
-    });
+      await store.createVault("test")
+      await expect(store.createVault("test")).rejects.toThrow(
+        'Vault "test" already exists',
+      )
+    })
 
     it("should list all vaults", async () => {
-      await store.createVault("health");
-      await store.createVault("financial");
+      await store.createVault("health")
+      await store.createVault("financial")
 
-      const vaults = store.listVaults();
-      expect(vaults).toContain("health");
-      expect(vaults).toContain("financial");
-    });
+      const vaults = store.listVaults()
+      expect(vaults).toContain("health")
+      expect(vaults).toContain("financial")
+    })
 
     it("should get vault by name", async () => {
-      await store.createVault("health");
+      await store.createVault("health")
 
-      const vault = store.getVault("health");
-      expect(vault).toBeDefined();
-      expect(store.getVault("nonexistent")).toBeUndefined();
-    });
+      const vault = store.getVault("health")
+      expect(vault).toBeDefined()
+      expect(store.getVault("nonexistent")).toBeUndefined()
+    })
 
     it("should delete a vault", async () => {
-      await store.createVault("temporary");
+      await store.createVault("temporary")
 
-      expect(await store.deleteVault("temporary")).toBe(true);
-      expect(store.getVault("temporary")).toBeUndefined();
-      expect(await store.deleteVault("temporary")).toBe(false);
-    });
-  });
-});
+      expect(await store.deleteVault("temporary")).toBe(true)
+      expect(store.getVault("temporary")).toBeUndefined()
+      expect(await store.deleteVault("temporary")).toBe(false)
+    })
+  })
+})
 
 describe("EncryptedVault", () => {
-  let store: ContextStore;
+  let store: ContextStore
 
   beforeEach(async () => {
-    store = new ContextStore();
-  });
+    store = new ContextStore()
+  })
 
   describe("data operations", () => {
     it("should store and retrieve data", async () => {
-      const vault = await store.createVault("test");
+      const vault = await store.createVault("test")
 
-      const entry = await vault.put("key1", { value: "test data" });
-      expect(entry.id).toBe("key1");
-      expect(entry.data).toEqual({ value: "test data" });
+      const entry = await vault.put("key1", { value: "test data" })
+      expect(entry.id).toBe("key1")
+      expect(entry.data).toEqual({ value: "test data" })
 
-      const retrieved = await vault.get("key1");
-      expect(retrieved?.data).toEqual({ value: "test data" });
-    });
+      const retrieved = await vault.get("key1")
+      expect(retrieved?.data).toEqual({ value: "test data" })
+    })
 
     it("should update existing data", async () => {
-      const vault = await store.createVault("test");
+      const vault = await store.createVault("test")
 
-      await vault.put("key1", { value: "original" });
-      const updated = await vault.put("key1", { value: "updated" });
+      await vault.put("key1", { value: "original" })
+      const updated = await vault.put("key1", { value: "updated" })
 
-      expect(updated.version).toBe(2);
-      expect(updated.data).toEqual({ value: "updated" });
-    });
+      expect(updated.version).toBe(2)
+      expect(updated.data).toEqual({ value: "updated" })
+    })
 
     it("should delete data", async () => {
-      const vault = await store.createVault("test");
+      const vault = await store.createVault("test")
 
-      await vault.put("key1", { value: "test" });
-      expect(await vault.has("key1")).toBe(true);
+      await vault.put("key1", { value: "test" })
+      expect(await vault.has("key1")).toBe(true)
 
-      expect(await vault.delete("key1")).toBe(true);
-      expect(await vault.has("key1")).toBe(false);
-    });
+      expect(await vault.delete("key1")).toBe(true)
+      expect(await vault.has("key1")).toBe(false)
+    })
 
     it("should list all keys", async () => {
-      const vault = await store.createVault("test");
+      const vault = await store.createVault("test")
 
-      await vault.put("key1", { value: 1 });
-      await vault.put("key2", { value: 2 });
-      await vault.put("key3", { value: 3 });
+      await vault.put("key1", { value: 1 })
+      await vault.put("key2", { value: 2 })
+      await vault.put("key3", { value: 3 })
 
-      const keys = await vault.keys();
-      expect(keys).toHaveLength(3);
-      expect(keys).toContain("key1");
-      expect(keys).toContain("key2");
-      expect(keys).toContain("key3");
-    });
-  });
-});
+      const keys = await vault.keys()
+      expect(keys).toHaveLength(3)
+      expect(keys).toContain("key1")
+      expect(keys).toContain("key2")
+      expect(keys).toContain("key3")
+    })
+  })
+})

--- a/tests/vectors.test.ts
+++ b/tests/vectors.test.ts
@@ -1,127 +1,127 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { SQLiteVectorStore } from "../src/vectors/index.js";
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { SQLiteVectorStore } from "../src/vectors/index.js"
 
 describe("SQLiteVectorStore", () => {
-  let store: SQLiteVectorStore;
-  const dimensions = 4; // Small dimensions for testing
+  let store: SQLiteVectorStore
+  const dimensions = 4 // Small dimensions for testing
 
   beforeEach(() => {
     store = new SQLiteVectorStore({
       path: ":memory:",
       dimensions,
       distanceMetric: "cosine",
-    });
-  });
+    })
+  })
 
   afterEach(() => {
-    store.close();
-  });
+    store.close()
+  })
 
   it("should add and count vectors", async () => {
-    await store.add("vec1", [0.1, 0.2, 0.3, 0.4]);
-    await store.add("vec2", [0.5, 0.6, 0.7, 0.8]);
+    await store.add("vec1", [0.1, 0.2, 0.3, 0.4])
+    await store.add("vec2", [0.5, 0.6, 0.7, 0.8])
 
-    const count = await store.count();
-    expect(count).toBe(2);
-  });
+    const count = await store.count()
+    expect(count).toBe(2)
+  })
 
   it("should reject vectors with wrong dimensions", async () => {
     await expect(store.add("bad", [0.1, 0.2])).rejects.toThrow(
-      "dimension mismatch"
-    );
-  });
+      "dimension mismatch",
+    )
+  })
 
   it("should search for similar vectors", async () => {
     // Add some test vectors
-    await store.add("similar", [0.9, 0.8, 0.7, 0.6]);
-    await store.add("different", [0.1, 0.1, 0.1, 0.1]);
-    await store.add("also-similar", [0.8, 0.9, 0.8, 0.7]);
+    await store.add("similar", [0.9, 0.8, 0.7, 0.6])
+    await store.add("different", [0.1, 0.1, 0.1, 0.1])
+    await store.add("also-similar", [0.8, 0.9, 0.8, 0.7])
 
     // Query with a vector similar to "similar" and "also-similar"
-    const results = await store.search([0.85, 0.85, 0.75, 0.65], 3);
+    const results = await store.search([0.85, 0.85, 0.75, 0.65], 3)
 
-    expect(results).toHaveLength(3);
+    expect(results).toHaveLength(3)
     // Results should be ordered by distance (ascending)
-    expect(results[0].distance).toBeLessThanOrEqual(results[1].distance);
-    expect(results[1].distance).toBeLessThanOrEqual(results[2].distance);
-  });
+    expect(results[0].distance).toBeLessThanOrEqual(results[1].distance)
+    expect(results[1].distance).toBeLessThanOrEqual(results[2].distance)
+  })
 
   it("should store and return metadata", async () => {
     await store.add("with-meta", [0.1, 0.2, 0.3, 0.4], {
       source: "test",
       category: "example",
-    });
+    })
 
-    const results = await store.search([0.1, 0.2, 0.3, 0.4], 1);
+    const results = await store.search([0.1, 0.2, 0.3, 0.4], 1)
 
-    expect(results[0].id).toBe("with-meta");
+    expect(results[0].id).toBe("with-meta")
     expect(results[0].metadata).toEqual({
       source: "test",
       category: "example",
-    });
-  });
+    })
+  })
 
   it("should delete vectors", async () => {
-    await store.add("to-delete", [0.1, 0.2, 0.3, 0.4]);
-    expect(await store.count()).toBe(1);
+    await store.add("to-delete", [0.1, 0.2, 0.3, 0.4])
+    expect(await store.count()).toBe(1)
 
-    const deleted = await store.delete("to-delete");
-    expect(deleted).toBe(true);
-    expect(await store.count()).toBe(0);
+    const deleted = await store.delete("to-delete")
+    expect(deleted).toBe(true)
+    expect(await store.count()).toBe(0)
 
-    const deletedAgain = await store.delete("to-delete");
-    expect(deletedAgain).toBe(false);
-  });
+    const deletedAgain = await store.delete("to-delete")
+    expect(deletedAgain).toBe(false)
+  })
 
   it("should update existing vectors", async () => {
-    await store.add("updating", [0.1, 0.1, 0.1, 0.1], { version: 1 });
-    await store.add("updating", [0.9, 0.9, 0.9, 0.9], { version: 2 });
+    await store.add("updating", [0.1, 0.1, 0.1, 0.1], { version: 1 })
+    await store.add("updating", [0.9, 0.9, 0.9, 0.9], { version: 2 })
 
     // Count should still be 1 (updated, not duplicated)
-    expect(await store.count()).toBe(1);
+    expect(await store.count()).toBe(1)
 
     // Search should find the updated vector
-    const results = await store.search([0.9, 0.9, 0.9, 0.9], 1);
-    expect(results[0].id).toBe("updating");
-    expect(results[0].metadata?.version).toBe(2);
-  });
+    const results = await store.search([0.9, 0.9, 0.9, 0.9], 1)
+    expect(results[0].id).toBe("updating")
+    expect(results[0].metadata?.version).toBe(2)
+  })
 
   it("should limit search results with k parameter", async () => {
     // Add 5 vectors
     for (let i = 0; i < 5; i++) {
-      await store.add(`vec${i}`, [i * 0.1, i * 0.2, i * 0.1, i * 0.2]);
+      await store.add(`vec${i}`, [i * 0.1, i * 0.2, i * 0.1, i * 0.2])
     }
 
-    const results = await store.search([0.5, 0.5, 0.5, 0.5], 2);
-    expect(results).toHaveLength(2);
-  });
-});
+    const results = await store.search([0.5, 0.5, 0.5, 0.5], 2)
+    expect(results).toHaveLength(2)
+  })
+})
 
 describe("SQLiteVectorStore with L2 distance", () => {
-  let store: SQLiteVectorStore;
+  let store: SQLiteVectorStore
 
   beforeEach(() => {
     store = new SQLiteVectorStore({
       path: ":memory:",
       dimensions: 3,
       distanceMetric: "l2",
-    });
-  });
+    })
+  })
 
   afterEach(() => {
-    store.close();
-  });
+    store.close()
+  })
 
   it("should work with L2 distance metric", async () => {
-    await store.add("origin", [0, 0, 0]);
-    await store.add("near", [0.1, 0.1, 0.1]);
-    await store.add("far", [1, 1, 1]);
+    await store.add("origin", [0, 0, 0])
+    await store.add("near", [0.1, 0.1, 0.1])
+    await store.add("far", [1, 1, 1])
 
-    const results = await store.search([0, 0, 0], 3);
+    const results = await store.search([0, 0, 0], 3)
 
-    expect(results[0].id).toBe("origin");
-    expect(results[0].distance).toBeCloseTo(0, 5);
-    expect(results[1].id).toBe("near");
-    expect(results[2].id).toBe("far");
-  });
-});
+    expect(results[0].id).toBe("origin")
+    expect(results[0].distance).toBeCloseTo(0, 5)
+    expect(results[1].id).toBe("near")
+    expect(results[2].id).toBe("far")
+  })
+})

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "tsup";
+import { defineConfig } from "tsup"
 
 export default defineConfig({
   entry: ["src/index.ts", "src/server.ts"],
@@ -7,4 +7,4 @@ export default defineConfig({
   sourcemap: true,
   clean: true,
   minify: false,
-});
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig } from "vitest/config"
 
 export default defineConfig({
   test: {
@@ -10,4 +10,4 @@ export default defineConfig({
       reporter: ["text", "json", "html"],
     },
   },
-});
+})


### PR DESCRIPTION
Adds [Biome](https://biomejs.dev) for combined linting and formatting.

## Changes
- Add `@biomejs/biome` dev dependency (pinned) and `biome.json` config.
- Scripts:
  - `lint` → `biome check . && tsc --noEmit` (preserves the previous type-check gate).
  - `format` → `biome check --write .`
  - `typecheck` → `tsc --noEmit` (standalone).
- Apply Biome formatting across `src/` and `tests/` (double quotes, no semicolons per config).
- Use optional catch binding in `src/crypto/index.ts` (the `error` binding was unused).

## Verification
- `pnpm run lint` → exit 0 (no errors/warnings).
- `pnpm exec vitest run` → 72/72 passing.

Base this after #6 (gitignore) if merging in order, though the two are independent.